### PR TITLE
remove scala scalap

### DIFF
--- a/json/src/main/scala/generic/package.fmpp.scala
+++ b/json/src/main/scala/generic/package.fmpp.scala
@@ -8,8 +8,6 @@ import scala.annotation.meta.getter
 import scala.collection.mutable.ListBuffer
 import scala.language.experimental.macros
 import scala.reflect.{ ClassTag, classTag }
-import scala.tools.scalap.scalax.rules.scalasig._
-import scala.util.control.NonFatal
 
 import io.sphere.util.{ Reflect, Memoizer }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,8 +25,7 @@ object SphereLibsBuild extends Build {
       "org.scalatest" %% "scalatest" % "2.2.5" % "test",
       "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",
       "ch.qos.logback" % "logback-classic" % "1.1.3" % "test"
-    ),
-    libraryDependencies += "org.scala-lang" % "scalap" % scalaVersion.value
+    )
   )
 
   lazy val libs = Project(

--- a/util/dependencies.sbt
+++ b/util/dependencies.sbt
@@ -2,5 +2,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2",
   "joda-time" % "joda-time" % "2.8.2",
   "org.joda" % "joda-convert" % "1.8.1",
-  "org.scalaz" %% "scalaz-core" % "7.1.4"
+  "org.scalaz" %% "scalaz-core" % "7.1.4",
+  "org.json4s" %% "json4s-scalap" % "3.3.0"
 )

--- a/util/src/main/scala/Reflect.scala
+++ b/util/src/main/scala/Reflect.scala
@@ -1,9 +1,6 @@
 package io.sphere.util
 
-import scala.reflect._
-import scala.tools.scalap.scalax.rules.scalasig._
-
-import java.util.concurrent.ConcurrentHashMap
+import org.json4s.scalap.scalasig._
 
 object Reflect extends Logging {
   case class CaseClassMeta(fields: IndexedSeq[CaseClassFieldMeta])


### PR DESCRIPTION
Use scalap from json4s to avoid big dependencies,
like scala-xml and parser combinators

@sphereio/backend please review