### PR TITLE
Implemented `deriveSingletonJSON`

### DIFF
--- a/json/src/test/scala/DeriveSingletonJSONSpec.scala
+++ b/json/src/test/scala/DeriveSingletonJSONSpec.scala
@@ -21,6 +21,17 @@ class DeriveSingletonJSONSpec extends WordSpec with MustMatchers {
       user must be (UserWithPicture("foo-123", Medium, "http://exmple.com"))
     }
 
+    "fail to read if singleton value is unknown" in {
+      a [JSONException] must be thrownBy getFromJSON[UserWithPicture](
+        """
+          {
+            "userId": "foo-123",
+            "pictureSize": "foo",
+            "pictureUrl": "http://exmple.com"
+          }
+        """)
+    }
+
     "write normal singleton values" in {
       val userJson = toJValue(UserWithPicture("foo-123", Medium, "http://exmple.com"))
 

--- a/json/src/test/scala/DeriveSingletonJSONSpec.scala
+++ b/json/src/test/scala/DeriveSingletonJSONSpec.scala
@@ -1,0 +1,91 @@
+import io.sphere.json.JSON
+import io.sphere.json._
+import io.sphere.json.generic._
+import org.scalatest.{MustMatchers, WordSpec}
+import org.json4s.jackson.JsonMethods._
+
+import scalaz.Success
+
+class DeriveSingletonJSONSpec extends WordSpec with MustMatchers {
+  "DeriveSingletonJSON" must {
+    "read normal singleton values" in {
+      val user = getFromJSON[UserWithPicture](
+        """
+          {
+            "userId": "foo-123",
+            "pictureSize": "Medium",
+            "pictureUrl": "http://exmple.com"
+          }
+        """)
+
+      user must be (UserWithPicture("foo-123", Medium, "http://exmple.com"))
+    }
+
+    "write normal singleton values" in {
+      val userJson = toJValue(UserWithPicture("foo-123", Medium, "http://exmple.com"))
+
+      val Success(expectedJson) = parseJSON("""
+        {
+          "userId": "foo-123",
+          "pictureSize": "Medium",
+          "pictureUrl": "http://exmple.com"
+        }
+        """)
+
+      userJson must be (expectedJson)
+    }
+
+    "read custom singleton values" in {
+      val user = getFromJSON[UserWithPicture](
+        """
+          {
+            "userId": "foo-123",
+            "pictureSize": "bar",
+            "pictureUrl": "http://exmple.com"
+          }
+        """)
+
+      user must be (UserWithPicture("foo-123", Custom, "http://exmple.com"))
+    }
+
+    "write custom singleton values" in {
+      val userJson = toJValue(UserWithPicture("foo-123", Custom, "http://exmple.com"))
+
+      val Success(expectedJson) = parseJSON("""
+        {
+          "userId": "foo-123",
+          "pictureSize": "bar",
+          "pictureUrl": "http://exmple.com"
+        }
+        """)
+
+      userJson must be (expectedJson)
+    }
+
+    "write and consequently read, which must produce the original value" in {
+      val originalUser = UserWithPicture("foo-123", Medium, "http://exmple.com")
+      val newUser = getFromJSON[UserWithPicture](compact(render(toJValue(originalUser))))
+
+      newUser must be (originalUser)
+    }
+  }
+}
+
+sealed abstract class PictureSize(val weight: Int, val height: Int)
+
+case object Small extends PictureSize(100, 100)
+case object Medium extends PictureSize(500, 450)
+case object Big extends PictureSize(1024, 2048)
+
+@JSONTypeHint("bar")
+case object Custom extends PictureSize(1, 2)
+
+object PictureSize {
+  implicit val json: JSON[PictureSize] = deriveSingletonJSON[PictureSize]
+}
+
+case class UserWithPicture(userId: String, pictureSize: PictureSize, pictureUrl: String)
+
+object UserWithPicture {
+  implicit val json: JSON[UserWithPicture] = deriveJSON[UserWithPicture]
+}


### PR DESCRIPTION
`deriveSingletonJSON` provides a nice alternative to `Enumeration` where you can represent enum-values as a sealed case objects.

@yanns @gogregor @agourlay @cneijenhuis can you please review? (I would recommend to start with the [test](https://github.com/sphereio/sphere-scala-libs/pull/15/files#diff-34956112346f71113f31225166d90298R74))