### PR TITLE
 is now treated the same way as  during the case-class serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * update scala to 2.11.8
 * update "com.fasterxml.jackson.core" % "jackson-databind" to 2.7.3
 * update "joda-time" % "joda-time" to 2.9.3
+* `JNothing` is now treated the same way as `JNull` during the case-class serialization
 
 ## 0.6.2 (2016-01-07)
 

--- a/json/src/main/scala/package.scala
+++ b/json/src/main/scala/package.scala
@@ -77,7 +77,7 @@ package object json extends Logging {
     default: Option[A] = None
   )(jval: JValue)(implicit jsonr: FromJSON[A]): JValidation[A] = jval match {
     case JObject(fields) =>
-      fields.find(_._1 == name).filterNot(_._2 == JNull)
+      fields.find(_._1 == name).filterNot(f ⇒ f._2 == JNull || f._2 == JNothing)
         .map(f => jsonr.read(f._2).fold(
           errs => Failure(errs map {
             case JSONParseError(msg) => JSONFieldError(List(name), msg)

--- a/json/src/test/scala/NullHandlingSpec.scala
+++ b/json/src/test/scala/NullHandlingSpec.scala
@@ -1,6 +1,7 @@
 package io.sphere.json
 
 import io.sphere.json.generic._
+import org.json4s.JsonAST.{JNothing, JObject}
 import org.scalatest.{MustMatchers, WordSpec}
 
 class NullHandlingSpec extends WordSpec with MustMatchers {
@@ -21,6 +22,17 @@ class NullHandlingSpec extends WordSpec with MustMatchers {
             "hiddenPocket": null
           }
         """)
+
+      jeans must be (Jeans(None, None, Set.empty, "secret"))
+    }
+
+    "should accept JNothing values and use default values for them" in {
+      val jeans = getFromJValue[Jeans](
+        JObject(
+          "leftPocket" → JNothing,
+          "rightPocket" → JNothing,
+          "backPocket" → JNothing,
+          "hiddenPocket" → JNothing))
 
       jeans must be (Jeans(None, None, Set.empty, "secret"))
     }


### PR DESCRIPTION
@sphereio/backend please review