### PR TITLE
test perf of jawn compared to jackson

### DIFF
--- a/benchmarks/dependencies.sbt
+++ b/benchmarks/dependencies.sbt
@@ -1,0 +1,4 @@
+libraryDependencies ++= Seq(
+  "org.spire-math" %% "jawn-parser" % "0.8.4",
+  "org.spire-math" %% "jawn-json4s" % "0.8.4"
+)

--- a/benchmarks/src/main/scala/json/JsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/JsonBenchmark.scala
@@ -7,13 +7,21 @@ import org.openjdk.jmh.annotations.Benchmark
 class JsonBenchmark {
 
   /* on local mac
-[info] Benchmark                       Mode  Cnt   Score   Error  Units
-[info] JsonBenchmark.parseFromString  thrpt   10  60.260 ± 1.812  ops/s
+[info] Benchmark                           Mode  Cnt   Score   Error  Units
+[info] JsonBenchmark.parseFromString      thrpt   10  60.228 ± 0.672  ops/s
+[info] JsonBenchmark.parseFromStringJawn  thrpt   10  95.485 ± 3.565  ops/s
    */
 
   @Benchmark
   def parseFromString(): Unit = {
     parseJson(StringInput(JsonBenchmark.json))
+  }
+
+  @Benchmark
+  def parseFromStringJawn(): Unit = {
+    import jawn.support.json4s.Parser
+
+    Parser.parseFromString(JsonBenchmark.json).get
   }
 
 }


### PR DESCRIPTION
@sphereio/backend I check the perf of jawn compared to what we are currently using (jackson).
And jawn seems much faster than jackson for this particular test json.
It may be worth a try.
