### PR TITLE
Add TypeSelectorContainer to typeswitch return type

### DIFF
--- a/json/src/main/scala/generic/package.fmpp.scala
+++ b/json/src/main/scala/generic/package.fmpp.scala
@@ -116,7 +116,7 @@ package object generic {
     *
     * This can be used as an alternative to an enum.
     */
-  def jsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON : ToJSON](selectors: List[TypeSelector[_]]): JSON[T] = {
+  def jsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON : ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
     val inSelectors = typeSelector[A] :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
       case container: TypeSelectorContainer => container.typeSelectors :+ s
@@ -168,13 +168,13 @@ package object generic {
   <#list 2..20 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def jsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] = jsonSingletonEnumSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
+  def jsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonSingletonEnumSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
   </#list>
 
   /** Creates a `JSON[T]` instance for some supertype `T`. The instance acts as a type-switch
     * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
     * on a field that acts as a type hint. */
-  def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON, A2 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] = {
+  def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON, A2 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
     val inSelectors = typeSelector[A1] :: typeSelector[A2] :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
       case container: TypeSelectorContainer => container.typeSelectors :+ s
@@ -229,7 +229,7 @@ package object generic {
   <#list 3..80 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
+  def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
   </#list>
 
   trait TypeSelectorContainer {


### PR DESCRIPTION
The `jsonTypeSwitch` internally creates a `JSON[T] with TypeSelectorContainer`. This is very useful if one wants to access the list of type names, for example.

However, the return type didn't declare it. With this PR, it does.

@sphereio/backend please review.