### PR TITLE
avoid serializing null

### DIFF
--- a/mongo/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
+++ b/mongo/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
@@ -7,6 +7,8 @@ import com.mongodb.BasicDBList
 import org.bson.types.ObjectId
 
 object DefaultMongoFormats extends DefaultMongoFormats
+
+// Represents an absent value for a field that should be not serialized.
 private [mongo] object MongoNothing
 
 /**

--- a/mongo/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
+++ b/mongo/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
@@ -7,6 +7,7 @@ import com.mongodb.BasicDBList
 import org.bson.types.ObjectId
 
 object DefaultMongoFormats extends DefaultMongoFormats
+private [mongo] object MongoNothing
 
 /**
   * [[MongoFormat]] for standard scala/mongo types
@@ -43,7 +44,7 @@ trait DefaultMongoFormats {
   implicit def optionFormat[A](implicit f: MongoFormat[A]): MongoFormat[Option[A]] = new MongoFormat[Option[A]] {
     override def toMongoValue(a: Option[A]) = a match {
       case Some(aa) => f.toMongoValue(aa)
-      case None => null
+      case None => MongoNothing
     }
     override def fromMongoValue(any: Any) = {
       Option(any).map(f.fromMongoValue)

--- a/mongo/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
+++ b/mongo/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
@@ -166,12 +166,12 @@ package object generic extends Logging {
       if (field.embedded)
         toMongo(e) match {
           case dbo2: DBObject => dbo.putAll(dbo2)
-          case null => ()
+          case MongoNothing => ()
           case x => dbo.put(field.name, x)
         }
       else
         toMongo(e) match {
-          case null => ()
+          case MongoNothing => ()
           case x => dbo.put(field.name, x)
         }
 

--- a/mongo/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
+++ b/mongo/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
@@ -166,10 +166,15 @@ package object generic extends Logging {
       if (field.embedded)
         toMongo(e) match {
           case dbo2: DBObject => dbo.putAll(dbo2)
+          case null => ()
           case x => dbo.put(field.name, x)
         }
       else
-        dbo.put(field.name, toMongo(e))
+        toMongo(e) match {
+          case null => ()
+          case x => dbo.put(field.name, x)
+        }
+
     }
 
   private def readField[A: MongoFormat](f: MongoFieldMeta, dbo: DBObject): A = {

--- a/mongo/src/test/scala/io/sphere/mongo/SerializationTest.scala
+++ b/mongo/src/test/scala/io/sphere/mongo/SerializationTest.scala
@@ -1,0 +1,26 @@
+package io.sphere.mongo
+
+import com.mongodb.DBObject
+import org.scalatest.{MustMatchers, WordSpec}
+import io.sphere.mongo.format.MongoFormat
+import io.sphere.mongo.format.DefaultMongoFormats._
+
+case class Something(a: Option[Int], b: Int)
+
+class SerializationTest extends WordSpec with MustMatchers {
+
+  "mongoProduct" must {
+    "generate a format that serializes optional fields with value None as BSON objects without that field" in {
+      val testFormat: MongoFormat[Something] =
+        io.sphere.mongo.generic.mongoProduct[Something, Option[Int], Int] {
+          (a: Option[Int]) => (b: Int) => Something(a, b)
+        }
+
+      val serializedObject = testFormat.toMongoValue(Something(None, 1)).asInstanceOf[DBObject]
+      serializedObject.keySet().contains("b") must be(true)
+      serializedObject.keySet().contains("a") must be(false)
+
+    }
+  }
+
+}


### PR DESCRIPTION
Test:

```
object Test {
  import DefaultMongoFormats._
  case class Something(a: Option[Int], b: Option[String])
  def test: MongoFormat[Something] = io.sphere.mongo.generic.mongoProduct[Something, Option[Int], Option[String]](
    (a: Option[Int]) => (b: Option[String]) => Something(a, b))

  def run = (
    test.toMongoValue(Something(Some(1), None)),
    test.toMongoValue(Something(None, Some("a")))
  )
}
```

```
scala> io.sphere.mongo.format.Test.run
res0: (Any, Any) = ({ "a" : 1},{ "b" : "a"})
```