### PR TITLE
add default mongo formats for Set and List

### DIFF
--- a/mongo/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
+++ b/mongo/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
@@ -71,4 +71,39 @@ trait DefaultMongoFormats {
       }
     }
   }
+
+  implicit def listFormat[A](implicit f: MongoFormat[A]): MongoFormat[List[A]] = new MongoFormat[List[A]] {
+    import scala.collection.JavaConverters._
+    override def toMongoValue(a: List[A]) = {
+      val m = new BasicDBList()
+      m.addAll(a.map(f.toMongoValue(_).asInstanceOf[AnyRef]).asJavaCollection)
+      m
+    }
+    override def fromMongoValue(any: Any): List[A] = {
+      any match {
+        case l: BasicDBList =>
+          val it = l.asInstanceOf[BasicDBList].iterator()
+          it.asScala.map(f.fromMongoValue).toList
+        case _ => throw new Exception(s"cannot read value from ${any.getClass.getName}")
+      }
+    }
+  }
+
+  implicit def setFormat[A](implicit f: MongoFormat[A]): MongoFormat[Set[A]] = new MongoFormat[Set[A]] {
+    import scala.collection.JavaConverters._
+    override def toMongoValue(a: Set[A]) = {
+      val m = new BasicDBList()
+      m.addAll(a.map(f.toMongoValue(_).asInstanceOf[AnyRef]).asJavaCollection)
+      m
+    }
+    override def fromMongoValue(any: Any): Set[A] = {
+      any match {
+        case l: BasicDBList =>
+          val it = l.asInstanceOf[BasicDBList].iterator()
+          it.asScala.map(f.fromMongoValue).toSet
+        case _ => throw new Exception(s"cannot read value from ${any.getClass.getName}")
+      }
+    }
+  }
+
 }

--- a/mongo/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
+++ b/mongo/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
@@ -1,0 +1,39 @@
+package io.sphere.mongo.format
+
+import io.sphere.mongo.format.DefaultMongoFormats._
+import org.bson.types.BasicBSONList
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{MustMatchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class DefaultMongoFormatsTest extends WordSpec with MustMatchers with GeneratorDrivenPropertyChecks {
+
+  "DefaultMongoFormats" must {
+    "support List" in {
+      val format = listFormat[String]
+      val list = Gen.listOf(Gen.alphaNumStr)
+
+      forAll(list) { l ⇒
+        val dbo = format.toMongoValue(l)
+        dbo.asInstanceOf[BasicBSONList].asScala.toList must be (l)
+        val resultList = format.fromMongoValue(dbo)
+        resultList must be (l)
+      }
+    }
+
+    "support Set" in {
+      val format = setFormat[String]
+      val set = Gen.listOf(Gen.alphaNumStr).map(_.toSet)
+
+      forAll(set) { s ⇒
+        val dbo = format.toMongoValue(s)
+        dbo.asInstanceOf[BasicBSONList].asScala.toSet must be (s)
+        val resultSet = format.fromMongoValue(dbo)
+        resultSet must be (s)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
@sphereio/backend please review

I decided not to make the implementation generic to avoid complexity and to be sure to have the best performances.