### PR TITLE
High precision money

### DIFF
--- a/json/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/src/main/scala/io/sphere/json/FromJSON.scala
@@ -203,7 +203,7 @@ object FromJSON {
           case None ⇒ moneyReader.read(value)
           case Some(Money.TypeName) ⇒ moneyReader.read(value)
           case Some(HighPrecisionMoney.TypeName) ⇒ highPrecisionMoneyReader.read(value)
-          case Some(tpe) ⇒ fail(s"Unknown money type '$tpe'. Available types are: 'centAmount', 'preciseAmount'.")
+          case Some(tpe) ⇒ fail(s"Unknown money type '$tpe'. Available types are: 'centPrecision', 'highPrecision'.")
         }
 
       case _ ⇒ fail("JSON object expected.")

--- a/json/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/src/main/scala/io/sphere/json/FromJSON.scala
@@ -174,7 +174,7 @@ object FromJSON {
     def read(value: JValue): JValidation[Money] = value match {
       case o: JObject ⇒
         (field[Long]("centAmount")(o), field[Currency]("currencyCode")(o)).mapN(
-          Money.makeWithCentAmount)
+          Money.fromCentAmount)
 
       case _ ⇒ fail("JSON object expected.")
     }
@@ -190,7 +190,7 @@ object FromJSON {
         (field[Long]("preciseAmount")(o),
           field[Int]("fractionDigits")(o),
           field[Currency]("currencyCode")(o),
-          field[Option[Long]]("centAmount")(o)).mapN(HighPrecisionMoney.makeWithPreciseAmount)
+          field[Option[Long]]("centAmount")(o)).mapN(HighPrecisionMoney.fromPreciseAmount)
 
       case _ ⇒ fail("JSON object expected.")
     }

--- a/json/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/src/main/scala/io/sphere/json/FromJSON.scala
@@ -201,8 +201,8 @@ object FromJSON {
       case o: JObject ⇒
         field[Option[String]]("type")(o).andThen {
           case None ⇒ moneyReader.read(value)
-          case Some("centAmount") ⇒ moneyReader.read(value)
-          case Some("preciseAmount") ⇒ highPrecisionMoneyReader.read(value)
+          case Some(Money.TypeName) ⇒ moneyReader.read(value)
+          case Some(HighPrecisionMoney.TypeName) ⇒ highPrecisionMoneyReader.read(value)
           case Some(tpe) ⇒ fail(s"Unknown money type '$tpe'. Available types are: 'centAmount', 'preciseAmount'.")
         }
 

--- a/json/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/src/main/scala/io/sphere/json/FromJSON.scala
@@ -10,7 +10,7 @@ import cats.instances.list._
 import cats.instances.vector._
 import cats.syntax.apply._
 import cats.syntax.traverse._
-import io.sphere.util.{LangTag, Money}
+import io.sphere.util.{BaseMoney, HighPrecisionMoney, LangTag, Money}
 import org.json4s.JsonAST._
 import org.joda.time._
 import org.joda.time.format.ISODateTimeFormat
@@ -170,17 +170,43 @@ object FromJSON {
 
   implicit val moneyReader: FromJSON[Money] = new FromJSON[Money] {
     override val fields = Set("centAmount", "currencyCode")
-    def read(jval: JValue): JValidation[Money] = jval match {
-      case o: JObject =>
-        (field[Currency]("currencyCode")(o),
-        field[Long]("centAmount")(o)).mapN(mkMoney)
-      case _ => fail("JSON object expected.")
-    }
 
-    private def mkMoney(currency: Currency, centAmount: Long): Money = {
-      Money.make(
-        centAmount / math.pow(10, currency.getDefaultFractionDigits),
-        currency)
+    def read(value: JValue): JValidation[Money] = value match {
+      case o: JObject ⇒
+        (field[Long]("centAmount")(o), field[Currency]("currencyCode")(o)).mapN(
+          Money.makeWithCentAmount)
+
+      case _ ⇒ fail("JSON object expected.")
+    }
+  }
+
+  implicit val highPrecisionMoneyReader: FromJSON[HighPrecisionMoney] = new FromJSON[HighPrecisionMoney] {
+    override val fields = Set("preciseAmount", "currencyCode", "fractionDigits")
+
+    import cats.implicits._
+    
+    def read(value: JValue): JValidation[HighPrecisionMoney] = value match {
+      case o: JObject ⇒
+        (field[Long]("preciseAmount")(o),
+          field[Int]("fractionDigits")(o),
+          field[Currency]("currencyCode")(o),
+          field[Option[Long]]("centAmount")(o)).mapN(HighPrecisionMoney.makeWithPreciseAmount)
+
+      case _ ⇒ fail("JSON object expected.")
+    }
+  }
+
+  implicit val baseMoneyReader: FromJSON[BaseMoney] = new FromJSON[BaseMoney] {
+    def read(value: JValue): JValidation[BaseMoney] = value match {
+      case o: JObject ⇒
+        field[Option[String]]("type")(o).andThen {
+          case None ⇒ moneyReader.read(value)
+          case Some("centAmount") ⇒ moneyReader.read(value)
+          case Some("preciseAmount") ⇒ highPrecisionMoneyReader.read(value)
+          case Some(tpe) ⇒ fail(s"Unknown money type '$tpe'. Available types are: 'centAmount', 'preciseAmount'.")
+        }
+
+      case _ ⇒ fail("JSON object expected.")
     }
   }
 

--- a/json/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/src/main/scala/io/sphere/json/FromJSON.scala
@@ -203,7 +203,7 @@ object FromJSON {
           case None ⇒ moneyReader.read(value)
           case Some(Money.TypeName) ⇒ moneyReader.read(value)
           case Some(HighPrecisionMoney.TypeName) ⇒ highPrecisionMoneyReader.read(value)
-          case Some(tpe) ⇒ fail(s"Unknown money type '$tpe'. Available types are: 'centPrecision', 'highPrecision'.")
+          case Some(tpe) ⇒ fail(s"Unknown money type '$tpe'. Available types are: '${Money.TypeName}', '${HighPrecisionMoney.TypeName}'.")
         }
 
       case _ ⇒ fail("JSON object expected.")

--- a/json/src/main/scala/io/sphere/json/ToJSON.scala
+++ b/json/src/main/scala/io/sphere/json/ToJSON.scala
@@ -88,7 +88,7 @@ object ToJSON {
 
   implicit val moneyWriter: ToJSON[Money] = new ToJSON[Money] {
     def write(m: Money): JValue = JObject(List(
-      JField("type", toJValue("centAmount")),
+      JField("type", toJValue(m.`type`)),
       JField("currencyCode", toJValue(m.currency)),
       JField("centAmount", toJValue(m.centAmount)),
       JField("fractionDigits", toJValue(m.currency.getDefaultFractionDigits))
@@ -97,7 +97,7 @@ object ToJSON {
 
   implicit val highPrecisionMoneyWriter: ToJSON[HighPrecisionMoney] = new ToJSON[HighPrecisionMoney] {
     def write(m: HighPrecisionMoney): JValue = JObject(List(
-      JField("type", toJValue("preciseAmount")),
+      JField("type", toJValue(m.`type`)),
       JField("currencyCode", toJValue(m.currency)),
       JField("centAmount", toJValue(m.centAmount)),
       JField("preciseAmount", toJValue(m.preciseAmountAsLong)),

--- a/json/src/main/scala/io/sphere/json/ToJSON.scala
+++ b/json/src/main/scala/io/sphere/json/ToJSON.scala
@@ -1,12 +1,11 @@
 package io.sphere.json
 
 import cats.data.NonEmptyList
+
 import scala.collection.breakOut
+import java.util.{Currency, Locale, UUID}
 
-import java.util.{ Locale, Currency, UUID }
-
-import io.sphere.util.Money
-
+import io.sphere.util.{BaseMoney, HighPrecisionMoney, Money}
 import org.json4s.JsonAST._
 import org.joda.time._
 import org.joda.time.format.ISODateTimeFormat
@@ -88,10 +87,29 @@ object ToJSON {
   }
 
   implicit val moneyWriter: ToJSON[Money] = new ToJSON[Money] {
-    def write(m: Money): JValue = JObject(
-      JField("currencyCode", toJValue(m.currency)) ::
-      JField("centAmount", toJValue(m.centAmount)) :: Nil
-    )
+    def write(m: Money): JValue = JObject(List(
+      JField("type", toJValue("centAmount")),
+      JField("currencyCode", toJValue(m.currency)),
+      JField("centAmount", toJValue(m.centAmount)),
+      JField("fractionDigits", toJValue(m.currency.getDefaultFractionDigits))
+    ))
+  }
+
+  implicit val highPrecisionMoneyWriter: ToJSON[HighPrecisionMoney] = new ToJSON[HighPrecisionMoney] {
+    def write(m: HighPrecisionMoney): JValue = JObject(List(
+      JField("type", toJValue("preciseAmount")),
+      JField("currencyCode", toJValue(m.currency)),
+      JField("centAmount", toJValue(m.centAmount)),
+      JField("preciseAmount", toJValue(m.preciseAmountAsLong)),
+      JField("fractionDigits", toJValue(m.fractionDigits))
+    ))
+  }
+
+  implicit def baseMoneyWriter: ToJSON[BaseMoney] = new ToJSON[BaseMoney] {
+    def write(m: BaseMoney): JValue = m match {
+      case m: Money ⇒ moneyWriter.write(m)
+      case m: HighPrecisionMoney ⇒ highPrecisionMoneyWriter.write(m)
+    }
   }
 
   implicit val currencyWriter: ToJSON[Currency] = new ToJSON[Currency] {

--- a/json/src/test/scala/io/sphere/json/JSONProperties.scala
+++ b/json/src/test/scala/io/sphere/json/JSONProperties.scala
@@ -11,6 +11,8 @@ import cats.syntax.eq._
 import org.joda.time._
 import org.scalacheck._
 
+import scala.math.BigDecimal.RoundingMode
+
 
 object JSONProperties extends Properties("JSON") {
   private def check[A: FromJSON: ToJSON: Eq](a: A): Boolean = {
@@ -68,7 +70,7 @@ object JSONProperties extends Properties("JSON") {
     Arbitrary(for {
       c <- Arbitrary.arbitrary[Currency]
       i <- Arbitrary.arbitrary[Int]
-    } yield Money.make(i, c))
+    } yield Money.fromDecimalAmount(i, c)(RoundingMode.HALF_EVEN))
 
   implicit def arbitraryUUID: Arbitrary[UUID] =
     Arbitrary(for {

--- a/json/src/test/scala/io/sphere/json/MoneySymmetrySpec.scala
+++ b/json/src/test/scala/io/sphere/json/MoneySymmetrySpec.scala
@@ -23,7 +23,7 @@ class MoneySymmetrySpec extends WordSpec with Matchers {
     "be symetric" in {
       implicit val mode = BigDecimal.RoundingMode.HALF_EVEN
 
-      val money = HighPrecisionMoney.makeWithoutCents(34.123456, 6, Currency.getInstance("EUR"))
+      val money = HighPrecisionMoney.fromDecimalAmount(34.123456, 6, Currency.getInstance("EUR"))
       val jsonAst = toJValue(money)
       val jsonAsString = compactJson(jsonAst)
       val Valid(readAst) = parseJSON(jsonAsString)

--- a/json/src/test/scala/io/sphere/json/MoneySymmetrySpec.scala
+++ b/json/src/test/scala/io/sphere/json/MoneySymmetrySpec.scala
@@ -1,6 +1,8 @@
 package io.sphere.json
 
-import io.sphere.util.Money
+import java.util.Currency
+
+import io.sphere.util.{BaseMoney, HighPrecisionMoney, Money}
 import cats.data.Validated.Valid
 import org.json4s.jackson.compactJson
 import org.scalatest.{Matchers, WordSpec}
@@ -14,6 +16,23 @@ class MoneySymmetrySpec extends WordSpec with Matchers {
       val Valid(readAst) = parseJSON(jsonAsString)
 
       jsonAst should equal (readAst)
+    }
+  }
+
+  "High precision money encoding/decoding" should {
+    "be symetric" in {
+      implicit val mode = BigDecimal.RoundingMode.HALF_EVEN
+
+      val money = HighPrecisionMoney.makeWithoutCents(34.123456, 6, Currency.getInstance("EUR"))
+      val jsonAst = toJValue(money)
+      val jsonAsString = compactJson(jsonAst)
+      val Valid(readAst) = parseJSON(jsonAsString)
+      val Valid(decodedMoney) = fromJSON[HighPrecisionMoney](jsonAsString)
+      val Valid(decodedBaseMoney) = fromJSON[BaseMoney](jsonAsString)
+
+      jsonAst should equal (readAst)
+      decodedMoney should equal (money)
+      decodedBaseMoney should equal (money)
     }
   }
 

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -9,6 +9,27 @@ import cats.Monoid
 import scala.math._
 import BigDecimal.RoundingMode._
 
+sealed trait BaseMoney {
+  def currency: Currency
+
+  def toHighPrecisionMoney(fractionDigits: Int)(implicit mode: RoundingMode): HighPrecisionMoney =
+    HighPrecisionMoney.make(this, fractionDigits)
+
+  def toMoneyWithLostPrecision: Money = this match {
+    case m: Money ⇒ m
+    case m: HighPrecisionMoney ⇒
+      Money.makeWithCentAmount(m.centAmount, currency)
+  }
+}
+
+object BaseMoney {
+  def requireSameCurrency(m1: BaseMoney, m2: BaseMoney): Unit =
+    require(m1.currency eq m2.currency, s"${m1.currency} != ${m2.currency}")
+
+  def toScalaRoundingMode(mode: java.math.RoundingMode): RoundingMode =
+    BigDecimal.RoundingMode(mode.ordinal())
+}
+
 /**
  * Represents an amount of money in a certain currency.
  *
@@ -20,12 +41,12 @@ import BigDecimal.RoundingMode._
  *               number of fractional digits of the currency.
  * @param currency The currency of the amount.
  */
-case class Money(amount: BigDecimal, currency: Currency) extends Ordered[Money] {
+case class Money(amount: BigDecimal, currency: Currency) extends BaseMoney with Ordered[Money] {
   import Money._
 
   require(amount.scale == currency.getDefaultFractionDigits,
-          "The scale of the given amount does not match the scale of the provided currency." +
-          " - " + amount.scale + " <-> " + currency.getDefaultFractionDigits)
+    "The scale of the given amount does not match the scale of the provided currency." +
+    " - " + amount.scale + " <-> " + currency.getDefaultFractionDigits)
 
   private val centFactor: Double = 1 / pow(10, currency.getDefaultFractionDigits)
 
@@ -43,21 +64,21 @@ case class Money(amount: BigDecimal, currency: Currency) extends Ordered[Money] 
   def apply(mc: MathContext): Money = make(this.amount(mc), this.currency)
 
   def + (m: Money): Money = {
-    requireSameCurrency(m)
+    BaseMoney.requireSameCurrency(this, m)
     make(this.amount + m.amount, this.currency)
   }
 
   def + (m: BigDecimal): Money = this + make(m, this.currency)
 
   def - (m: Money): Money = {
-    requireSameCurrency(m)
+    BaseMoney.requireSameCurrency(this, m)
     make(this.amount - m.amount, this.currency)
   }
 
   def - (m: BigDecimal): Money = this - make(m, this.currency)
 
   def * (m: Money)(implicit mode: RoundingMode): Money = {
-    requireSameCurrency(m)
+    BaseMoney.requireSameCurrency(this, m)
     this * m.amount
   }
 
@@ -67,9 +88,9 @@ case class Money(amount: BigDecimal, currency: Currency) extends Ordered[Money] 
 
   /** Divide to integral value + remainder */
   def /% (m: BigDecimal)(implicit mode: RoundingMode): (Money, Money) = {
-    val result_remainder = this.amount /% m
-    ( make(result_remainder._1, this.currency)
-    , make(result_remainder._2, this.currency) )
+    val (result, remainder) = this.amount /% m
+
+    (make(result, this.currency), make(remainder, this.currency))
   }
 
   def % (m: Money)(implicit mode: RoundingMode): Money = this.remainder(m)
@@ -77,7 +98,7 @@ case class Money(amount: BigDecimal, currency: Currency) extends Ordered[Money] 
   def % (m: BigDecimal)(implicit mode: RoundingMode): Money = this.remainder(make(m, this.currency))
 
   def remainder(m: Money)(implicit mode: RoundingMode): Money = {
-    requireSameCurrency(m)
+    BaseMoney.requireSameCurrency(this, m)
     make(this.amount.remainder(m.amount), this.currency)
   }
 
@@ -104,7 +125,7 @@ case class Money(amount: BigDecimal, currency: Currency) extends Ordered[Money] 
   }
 
   def compare(that: Money): Int =  {
-    requireSameCurrency(that)
+    BaseMoney.requireSameCurrency(this, that)
     this.amount compare that.amount
   }
 
@@ -115,9 +136,6 @@ case class Money(amount: BigDecimal, currency: Currency) extends Ordered[Money] 
     require(nf.getCurrency eq this.currency)
     nf.format(this.amount.doubleValue) + " " + this.currency.getSymbol
   }
-
-  private def requireSameCurrency(m: Money): Unit =
-    require(this.currency eq m.currency, s"${this.currency} != ${m.currency}")
 }
 
 object Money {
@@ -128,17 +146,29 @@ object Money {
     def JPY = Money.JPY(amount)
   }
 
-  def EUR(amount: BigDecimal): Money = make(amount, Currency.getInstance("EUR"))
-  def USD(amount: BigDecimal): Money = make(amount, Currency.getInstance("USD"))
-  def GBP(amount: BigDecimal): Money = make(amount, Currency.getInstance("GBP"))
-  def JPY(amount: BigDecimal): Money = make(amount, Currency.getInstance("JPY"))
+  def EUR(amount: BigDecimal): Money = makeWithoutCents(amount, Currency.getInstance("EUR"))(BigDecimal.RoundingMode.HALF_EVEN)
+  def USD(amount: BigDecimal): Money = makeWithoutCents(amount, Currency.getInstance("USD"))(BigDecimal.RoundingMode.HALF_EVEN)
+  def GBP(amount: BigDecimal): Money = makeWithoutCents(amount, Currency.getInstance("GBP"))(BigDecimal.RoundingMode.HALF_EVEN)
+  def JPY(amount: BigDecimal): Money = makeWithoutCents(amount, Currency.getInstance("JPY"))(BigDecimal.RoundingMode.HALF_EVEN)
 
   /** Creates a new Money object, forcing the scale according to the currency. */
+  @deprecated("Please use more explicit factory methods `makeWithoutCents`/`makeWithCentAmount`", "0.9.4")
   def make(amount: BigDecimal, currency: Currency, mode: RoundingMode): Money =
     Money(amount.setScale(currency.getDefaultFractionDigits, mode), currency)
 
+  @deprecated("Please use more explicit factory methods `makeWithoutCents`/`makeWithCentAmount`", "0.9.4")
   def make(amount: BigDecimal, currency: Currency): Money =
     make(amount, currency, BigDecimal.RoundingMode.HALF_EVEN)
+
+  def makeWithoutCents(amount: BigDecimal, currency: Currency)(implicit mode: RoundingMode) =
+    Money(amount.setScale(currency.getDefaultFractionDigits, mode), currency)
+
+  def makeWithCentAmount(centAmount: Long, currency: Currency) = {
+    val centFactor = BigDecimal(1) / BigDecimal(10).pow(currency.getDefaultFractionDigits)
+    val amount = BigDecimal(centAmount) * centFactor
+
+    makeWithoutCents(amount, currency)(BigDecimal.RoundingMode.UNNECESSARY)
+  }
 
   implicit def moneyMonoid(implicit c: Currency): Monoid[Money] = new Monoid[Money] {
     def combine(x: Money, y: Money): Money = x + y
@@ -148,5 +178,181 @@ object Money {
   implicit def moneyMonoid(implicit c: Currency, mode: RoundingMode): Monoid[Money] = new Monoid[Money] {
     def combine(x: Money, y: Money): Money = x + y
     val empty: Money = Money.make(0, c, mode)
+  }
+}
+
+case class HighPrecisionMoney(amount: BigDecimal, fractionDigits: Int, centAmount: Long, currency: Currency) extends BaseMoney with Ordered[Money] {
+  import HighPrecisionMoney._
+
+  require(amount.scale == fractionDigits,
+    "The scale of the given amount does not match the scale of the provided currency." +
+    " - " + amount.scale + " <-> " + fractionDigits)
+
+  lazy val preciseAmountAsLong: Long =
+    (amount * BigDecimal(10).pow(fractionDigits)).toLongExact
+
+  def withFractionDigits(fd: Int)(implicit mode: RoundingMode) = {
+    val newAmount = amount.setScale(fd, mode)
+
+    HighPrecisionMoney(newAmount, fd, roundToCents(newAmount, currency), currency)
+  }
+
+  def + (other: HighPrecisionMoney): HighPrecisionMoney =
+    calc(this, other, _ + _)
+
+  def + (other: BigDecimal)(implicit mode: RoundingMode): HighPrecisionMoney =
+    this + makeWithoutCents(other, this.fractionDigits, this.currency)
+
+  def - (other: HighPrecisionMoney): HighPrecisionMoney =
+    calc(this, other, _ - _)
+
+  def - (other: BigDecimal)(implicit mode: RoundingMode): HighPrecisionMoney =
+    this - makeWithoutCents(other, this.fractionDigits, this.currency)
+
+  def * (other: HighPrecisionMoney)(implicit mode: RoundingMode): HighPrecisionMoney =
+    calc(this, other, _ * _)
+
+  def * (other: BigDecimal)(implicit mode: RoundingMode): HighPrecisionMoney =
+    this * makeWithoutCents(other, this.fractionDigits, this.currency)
+
+  /** Divide to integral value + remainder */
+  def /% (m: BigDecimal)(implicit mode: RoundingMode): (HighPrecisionMoney, HighPrecisionMoney) = {
+    val (result, remainder) = this.amount /% m
+
+    makeWithoutCents(result, fractionDigits, this.currency) →
+      makeWithoutCents(remainder, fractionDigits, this.currency)
+  }
+
+  def % (other: HighPrecisionMoney)(implicit mode: RoundingMode): HighPrecisionMoney =
+    this.remainder(other)
+
+  def % (other: BigDecimal)(implicit mode: RoundingMode): HighPrecisionMoney =
+    this.remainder(makeWithoutCents(other, this.fractionDigits, this.currency))
+
+  def remainder(other: HighPrecisionMoney)(implicit mode: RoundingMode): HighPrecisionMoney =
+    calc(this, other, _ remainder _)
+
+  def remainder(other: BigDecimal)(implicit mode: RoundingMode): HighPrecisionMoney =
+    this.remainder(makeWithoutCents(other, this.fractionDigits, this.currency))
+
+  def unary_- = makeWithoutCents(-this.amount, this.fractionDigits, this.currency)(BaseMoney.toScalaRoundingMode(amount.mc.getRoundingMode))
+
+  /**
+   * Partitions this amount of money into several parts where the size of the individual
+   * parts are defined by the given ratios. The partitioning takes care of not losing or gaining
+   * any money by distributing any remaining "cents" evenly across the partitions.
+   *
+   * <p>Example: (0.05 EUR) partition (3,7) == Seq(0.02 EUR, 0.03 EUR)</p>
+   */
+  def partition(ratios: Int*)(implicit mode: RoundingMode): Seq[HighPrecisionMoney] = {
+    val total = ratios.sum
+    val factor = BigDecimal(1) / BigDecimal(10).pow(fractionDigits)
+    val amountAsInt = (this.amount / factor).toBigInt
+    val portionAmounts = ratios.map(amountAsInt * _ / total)
+    var remainder = portionAmounts.foldLeft(amountAsInt)(_ - _)
+
+    portionAmounts.map { portionAmount ⇒
+      remainder -= 1
+
+      makeWithoutCents(BigDecimal(portionAmount + (if (remainder >= 0) 1 else 0)) * factor, this.fractionDigits, this.currency)
+    }
+  }
+
+  def compare(other: Money): Int = {
+    BaseMoney.requireSameCurrency(this, other)
+
+    this.amount compare other.amount
+  }
+
+  override def toString = ("%." + this.fractionDigits + "f %s")
+    .format(this.amount, this.currency.getSymbol)
+
+  def toString(nf: NumberFormat) = {
+    require(nf.getCurrency eq this.currency)
+
+    nf.format(this.amount.doubleValue) + " " + this.currency.getSymbol
+  }
+}
+
+object HighPrecisionMoney {
+  final implicit class HighPrecisionMoneyNotation(val amount: Double) extends AnyVal {
+    def EUR = HighPrecisionMoney.EUR(amount)
+    def USD = HighPrecisionMoney.USD(amount)
+    def GBP = HighPrecisionMoney.GBP(amount)
+    def JPY = HighPrecisionMoney.JPY(amount)
+  }
+
+  def EUR(amount: BigDecimal) = simpleValueMeantToBeUsedOnlyInTests(amount, "EUR")
+  def USD(amount: BigDecimal) = simpleValueMeantToBeUsedOnlyInTests(amount, "USD")
+  def GBP(amount: BigDecimal) = simpleValueMeantToBeUsedOnlyInTests(amount, "GBP")
+  def JPY(amount: BigDecimal) = simpleValueMeantToBeUsedOnlyInTests(amount, "JPY")
+
+  private def simpleValueMeantToBeUsedOnlyInTests(amount: BigDecimal, currencyCode: String): HighPrecisionMoney = {
+    val currency = Currency.getInstance(currencyCode)
+
+    makeWithoutCents(amount, currency.getDefaultFractionDigits, currency)(BigDecimal.RoundingMode.HALF_EVEN)
+  }
+
+  def roundToCents(amount: BigDecimal, currency: Currency)(implicit mode: RoundingMode): Long =
+    (amount.setScale(currency.getDefaultFractionDigits, mode) / centFactor(currency)).toLong
+
+  def sameScale(m1: HighPrecisionMoney, m2: HighPrecisionMoney): (BigDecimal, BigDecimal, Int) = {
+    val newFractionDigits = math.max(m1.fractionDigits, m2.fractionDigits)
+
+    def scale(m: HighPrecisionMoney, s: Int) =
+      if (m.fractionDigits < s) m.amount.setScale(s)
+      else if (m.fractionDigits == s) m.amount
+      else throw new IllegalStateException("Downscale is not allowed/expected at this point!")
+
+    (scale(m1, newFractionDigits), scale(m2, newFractionDigits), newFractionDigits)
+  }
+
+  def calc(m1: HighPrecisionMoney, m2: HighPrecisionMoney, fn: (BigDecimal, BigDecimal) ⇒ BigDecimal) = {
+    BaseMoney.requireSameCurrency(m1, m2)
+
+    implicit val rm: RoundingMode = BaseMoney.toScalaRoundingMode(m1.amount.mc.getRoundingMode)
+    val (a1, a2, fd) = sameScale(m1, m2)
+
+    makeWithoutCents(fn(a1, a2), fd, m1.currency)
+  }
+
+  def factor(fractionDigits: Int) = BigDecimal(1) / BigDecimal(10).pow(fractionDigits)
+  def centFactor(currency: Currency) = factor(currency.getDefaultFractionDigits)
+
+  def makeWithoutCents(amount: BigDecimal, fractionDigits: Int, currency: Currency)(implicit mode: RoundingMode) = {
+    val scaledAmount = amount.setScale(fractionDigits, mode)
+
+    HighPrecisionMoney(scaledAmount, fractionDigits, roundToCents(scaledAmount, currency), currency)
+  }
+
+  def makeWithCentAmount(centAmount: Long, fractionDigits: Int, currency: Currency) = {
+    val amount = BigDecimal(centAmount) * centFactor(currency)
+
+    HighPrecisionMoney(amount.setScale(fractionDigits, BigDecimal.RoundingMode.UNNECESSARY), fractionDigits, centAmount, currency)
+  }
+
+  /* centAmount provides an escape hatch in cases where the default rounding mode is not applicable */
+  def makeWithPreciseAmount(preciseAmount: Long, fractionDigits: Int, currency: Currency, centAmount: Option[Long]) = {
+    val amount = BigDecimal(preciseAmount) * factor(fractionDigits)
+    val scaledAmount = amount.setScale(fractionDigits, BigDecimal.RoundingMode.UNNECESSARY)
+
+    // TODO: revisit this part! the rounding mode might be dynamic and configured elsewhere
+    val actualCentAmount = centAmount getOrElse roundToCents(scaledAmount, currency)(
+      BigDecimal.RoundingMode.HALF_EVEN)
+
+    HighPrecisionMoney(scaledAmount, fractionDigits, actualCentAmount, currency)
+  }
+
+  def make(money: Money, fractionDigits: Int)(implicit mode: RoundingMode): HighPrecisionMoney =
+    HighPrecisionMoney(money.amount.setScale(fractionDigits, mode), fractionDigits, money.centAmount, money.currency)
+
+  def make(money: BaseMoney, fractionDigits: Int)(implicit mode: RoundingMode): HighPrecisionMoney = money match {
+    case m: Money ⇒ make(m, fractionDigits)
+    case hp: HighPrecisionMoney ⇒ hp.withFractionDigits(fractionDigits)
+  }
+
+  def monoid(fractionDigits: Int, c: Currency): Monoid[HighPrecisionMoney] = new Monoid[HighPrecisionMoney] {
+    def combine(x: HighPrecisionMoney, y: HighPrecisionMoney): HighPrecisionMoney = x + y
+    val empty: HighPrecisionMoney = HighPrecisionMoney.makeWithCentAmount(0L, fractionDigits, c)
   }
 }

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -264,6 +264,9 @@ case class HighPrecisionMoney private (amount: BigDecimal, fractionDigits: Int, 
     HighPrecisionMoney(newAmount, fd, roundToCents(newAmount, currency), currency)
   }
 
+  def updateCentAmountWithRoundingMode(implicit mode: RoundingMode) =
+    copy(centAmount = roundToCents(amount, currency))
+
   def + (other: HighPrecisionMoney)(implicit mode: RoundingMode): HighPrecisionMoney =
     calc(this, other, _ + _)
 

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -1,0 +1,136 @@
+import java.util.Currency
+
+import io.sphere.util.{BaseMoney, HighPrecisionMoney, Money}
+import org.scalatest._
+
+import scala.collection.mutable.ArrayBuffer
+import scala.language.postfixOps
+
+class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
+  import Money._
+
+  implicit val defaultRoundingMode = BigDecimal.RoundingMode.HALF_EVEN
+
+  val Euro: Currency = Currency.getInstance("EUR")
+
+  describe("High Precision Money") {
+
+    it("should allow creation of high precision money") {
+      HighPrecisionMoney(amount = 0.01, fractionDigits = 2, centAmount = 1, Euro) must equal(
+        HighPrecisionMoney(amount = 0.01, fractionDigits = 2, centAmount = 1, Euro))
+    }
+
+    it("should not allow creation of high precision money without sufficient scale") {
+      val thrown = intercept[IllegalArgumentException] {
+        HighPrecisionMoney(amount = 1, fractionDigits = 2, centAmount = 1, Euro)
+      }
+
+      assert(thrown.getMessage == "requirement failed: The scale of the given amount does not match the scale of the provided currency. - 0 <-> 2")
+    }
+
+    it("should not allow creation of high precision money with less fraction digits than the currency has") {
+      val thrown = intercept[IllegalArgumentException] {
+        HighPrecisionMoney(amount = 0.01, fractionDigits = 1, centAmount = 1, Euro)
+      }
+
+      assert(thrown.getMessage == "requirement failed: The scale of the given amount does not match the scale of the provided currency. - 2 <-> 1")
+    }
+
+    it("should convert precise amount to long value correctly") {
+      HighPrecisionMoney(amount = BigDecimal("0.0001"), fractionDigits = 4, centAmount = 0, Euro).preciseAmountAsLong must equal(1)
+    }
+
+    it("should reduce fraction digits as expected") {
+      HighPrecisionMoney(amount = BigDecimal("0.0001"), fractionDigits = 4, centAmount = 0, Euro).withFractionDigits(2).preciseAmountAsLong must equal(0)
+    }
+
+    it("should support the unary '-' operator.") {
+      -HighPrecisionMoney(amount = 0.01, fractionDigits = 2, centAmount = 1, Euro) must equal (HighPrecisionMoney(amount = -0.01, fractionDigits = 2, centAmount = -1, Euro))
+    }
+
+    it("should support the binary '+' operator.") {
+      HighPrecisionMoney(amount = 0.001, fractionDigits = 3, centAmount = 0, Euro) +  HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) must equal(
+        HighPrecisionMoney(amount = 0.003, fractionDigits = 3, centAmount = 0, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro) +  Money(0.01, Euro) must equal(
+        HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 2, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).+(BigDecimal("0.005")) must equal(
+        HighPrecisionMoney(amount = BigDecimal("0.010"), fractionDigits = 3, centAmount = 1, Euro)
+      )
+    }
+
+    it("should support the binary '-' operator.") {
+      HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) -  HighPrecisionMoney(amount = 0.001, fractionDigits = 3, centAmount = 0, Euro) must equal(
+        HighPrecisionMoney(amount = 0.001, fractionDigits = 3, centAmount = 0, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 0, Euro) -  Money(0.01, Euro) must equal(
+        HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).-(BigDecimal("0.005")) must equal(
+        HighPrecisionMoney(amount = BigDecimal("0.000"), fractionDigits = 3, centAmount = 0, Euro)
+      )
+    }
+
+    it("should support the binary '*' operator.") {
+      HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) *  HighPrecisionMoney(amount = BigDecimal("5.00"), fractionDigits = 2, centAmount = 500, Euro) must equal(
+        HighPrecisionMoney(amount = BigDecimal("0.010"), fractionDigits = 3, centAmount = 1, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 0, Euro) *  Money(BigDecimal("100.00"), Euro) must equal(
+        HighPrecisionMoney(amount = BigDecimal("1.500"), fractionDigits = 3, centAmount = 150, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).*(BigDecimal("0.005")) must equal(
+        HighPrecisionMoney(amount = BigDecimal("0.000"), fractionDigits = 3, centAmount = 0, Euro)
+      )
+    }
+
+    it("should support the binary '%' operator.") {
+      HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) *  HighPrecisionMoney(amount = BigDecimal("5.00"), fractionDigits = 2, centAmount = 500, Euro) must equal(
+        HighPrecisionMoney(amount = BigDecimal("0.010"), fractionDigits = 3, centAmount = 1, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 0, Euro) *  Money(BigDecimal("100.00"), Euro) must equal(
+        HighPrecisionMoney(amount = BigDecimal("1.500"), fractionDigits = 3, centAmount = 150, Euro)
+      )
+
+      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).*(BigDecimal("0.005")) must equal(
+        HighPrecisionMoney(amount = BigDecimal("0.000"), fractionDigits = 3, centAmount = 0, Euro)
+      )
+    }
+
+    it("should support the binary '/%' operator.") {
+      HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro)./%(3.00) must equal(
+        (HighPrecisionMoney(amount = BigDecimal("3.000"), fractionDigits = 3, centAmount = 300, Euro),
+          HighPrecisionMoney(amount = BigDecimal("1.000"), fractionDigits = 3, centAmount = 100, Euro))
+      )
+    }
+
+    it("should support the remainder operator.") {
+      HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro).remainder(3.00) must equal(
+        HighPrecisionMoney(amount = BigDecimal("1.000"), fractionDigits = 3, centAmount = 100, Euro))
+
+      HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro).remainder(
+        HighPrecisionMoney(amount = BigDecimal("3.000"), fractionDigits = 3, centAmount = 300, Euro)) must equal(
+          HighPrecisionMoney(amount = BigDecimal("1.000"), fractionDigits = 3, centAmount = 100, Euro))
+    }
+
+    it("should partition the value properly.") {
+      val a = HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro).partition(1, 2, 3) must equal(
+        ArrayBuffer(
+          HighPrecisionMoney(amount = BigDecimal("1.667"), fractionDigits = 3, centAmount = 167, Euro),
+          HighPrecisionMoney(amount = BigDecimal("3.333"), fractionDigits = 3, centAmount = 333, Euro),
+          HighPrecisionMoney(amount = BigDecimal("5.000"), fractionDigits = 3, centAmount = 500, Euro)
+        )
+      )
+    }
+
+    //make constructors private, only use from centAmount, fromDecimalAmount
+
+  }
+}

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.postfixOps
 
 class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
-  import Money._
+  import HighPrecisionMoney._
 
   implicit val defaultRoundingMode = BigDecimal.RoundingMode.HALF_EVEN
 
@@ -16,8 +16,7 @@ class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
   describe("High Precision Money") {
 
     it("should allow creation of high precision money") {
-      HighPrecisionMoney(amount = 0.01, fractionDigits = 2, centAmount = 1, Euro) must equal(
-        HighPrecisionMoney(amount = 0.01, fractionDigits = 2, centAmount = 1, Euro))
+      (BigDecimal(0.01) EUR) must equal(BigDecimal(0.01) EUR)
     }
 
     it("should not allow creation of high precision money without sufficient scale") {
@@ -30,107 +29,100 @@ class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
 
     it("should not allow creation of high precision money with less fraction digits than the currency has") {
       val thrown = intercept[IllegalArgumentException] {
-        HighPrecisionMoney(amount = 0.01, fractionDigits = 1, centAmount = 1, Euro)
+        BigDecimal(0.01) EUR_PRECISE 1
       }
 
-      assert(thrown.getMessage == "requirement failed: The scale of the given amount does not match the scale of the provided currency. - 2 <-> 1")
+      assert(thrown.getMessage == "requirement failed: `fractionDigits` should be  >= than the default fraction digits of the currency.")
     }
 
     it("should convert precise amount to long value correctly") {
-      HighPrecisionMoney(amount = BigDecimal("0.0001"), fractionDigits = 4, centAmount = 0, Euro).preciseAmountAsLong must equal(1)
+      (BigDecimal("0.0001") EUR_PRECISE 4).preciseAmountAsLong must equal (1)
     }
 
     it("should reduce fraction digits as expected") {
-      HighPrecisionMoney(amount = BigDecimal("0.0001"), fractionDigits = 4, centAmount = 0, Euro).withFractionDigits(2).preciseAmountAsLong must equal(0)
+      (BigDecimal("0.0001") EUR_PRECISE 4).withFractionDigits(2).preciseAmountAsLong must equal(0)
     }
 
     it("should support the unary '-' operator.") {
-      -HighPrecisionMoney(amount = 0.01, fractionDigits = 2, centAmount = 1, Euro) must equal (HighPrecisionMoney(amount = -0.01, fractionDigits = 2, centAmount = -1, Euro))
+      -(BigDecimal(0.01) EUR_PRECISE 2) must equal (BigDecimal(-0.01) EUR_PRECISE 2)
     }
 
     it("should support the binary '+' operator.") {
-      HighPrecisionMoney(amount = 0.001, fractionDigits = 3, centAmount = 0, Euro) +  HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) must equal(
-        HighPrecisionMoney(amount = 0.003, fractionDigits = 3, centAmount = 0, Euro)
+      (BigDecimal(0.001) EUR_PRECISE 3) + (BigDecimal(0.002) EUR_PRECISE 3) must equal(
+        BigDecimal(0.003) EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro) +  Money(0.01, Euro) must equal(
-        HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 2, Euro)
+      (BigDecimal(0.005) EUR_PRECISE 3) + Money(0.01, Euro) must equal(
+        BigDecimal(0.015) EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).+(BigDecimal("0.005")) must equal(
-        HighPrecisionMoney(amount = BigDecimal("0.010"), fractionDigits = 3, centAmount = 1, Euro)
+      (BigDecimal(0.005) EUR_PRECISE 3) + BigDecimal("0.005") must equal(
+        BigDecimal("0.010") EUR_PRECISE 3
       )
     }
 
     it("should support the binary '-' operator.") {
-      HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) -  HighPrecisionMoney(amount = 0.001, fractionDigits = 3, centAmount = 0, Euro) must equal(
-        HighPrecisionMoney(amount = 0.001, fractionDigits = 3, centAmount = 0, Euro)
+      (BigDecimal(0.002) EUR_PRECISE 3) - (BigDecimal(0.001) EUR_PRECISE 3) must equal(
+        BigDecimal(0.001) EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 0, Euro) -  Money(0.01, Euro) must equal(
-        HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro)
+      (BigDecimal(0.015) EUR_PRECISE 3) - Money(0.01, Euro) must equal(
+        BigDecimal(0.005) EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).-(BigDecimal("0.005")) must equal(
-        HighPrecisionMoney(amount = BigDecimal("0.000"), fractionDigits = 3, centAmount = 0, Euro)
+      (BigDecimal(0.005) EUR_PRECISE 3) - BigDecimal("0.005") must equal(
+        BigDecimal(0.000) EUR_PRECISE 3
       )
     }
 
     it("should support the binary '*' operator.") {
-      HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) *  HighPrecisionMoney(amount = BigDecimal("5.00"), fractionDigits = 2, centAmount = 500, Euro) must equal(
-        HighPrecisionMoney(amount = BigDecimal("0.010"), fractionDigits = 3, centAmount = 1, Euro)
+      (BigDecimal(0.002) EUR_PRECISE 3) * (BigDecimal("5.00") EUR_PRECISE 2) must equal(
+        BigDecimal("0.010") EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 0, Euro) *  Money(BigDecimal("100.00"), Euro) must equal(
-        HighPrecisionMoney(amount = BigDecimal("1.500"), fractionDigits = 3, centAmount = 150, Euro)
+      (BigDecimal(0.015) EUR_PRECISE 3) * Money(BigDecimal("100.00"), Euro) must equal(
+        BigDecimal("1.500") EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).*(BigDecimal("0.005")) must equal(
-        HighPrecisionMoney(amount = BigDecimal("0.000"), fractionDigits = 3, centAmount = 0, Euro)
+      (BigDecimal(0.005) EUR_PRECISE 3) * BigDecimal("0.005") must equal(
+        BigDecimal("0.000") EUR_PRECISE 3
       )
     }
 
     it("should support the binary '%' operator.") {
-      HighPrecisionMoney(amount = 0.002, fractionDigits = 3, centAmount = 0, Euro) *  HighPrecisionMoney(amount = BigDecimal("5.00"), fractionDigits = 2, centAmount = 500, Euro) must equal(
-        HighPrecisionMoney(amount = BigDecimal("0.010"), fractionDigits = 3, centAmount = 1, Euro)
+      (BigDecimal("0.010") EUR_PRECISE 3) % (BigDecimal("5.00") EUR_PRECISE 2) must equal(
+        BigDecimal("0.010") EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.015, fractionDigits = 3, centAmount = 0, Euro) *  Money(BigDecimal("100.00"), Euro) must equal(
-        HighPrecisionMoney(amount = BigDecimal("1.500"), fractionDigits = 3, centAmount = 150, Euro)
+      (BigDecimal("100.000") EUR_PRECISE 3) % Money(BigDecimal("100.00"), Euro) must equal(
+        BigDecimal("0.000") EUR_PRECISE 3
       )
 
-      HighPrecisionMoney(amount = 0.005, fractionDigits = 3, centAmount = 0, Euro).*(BigDecimal("0.005")) must equal(
-        HighPrecisionMoney(amount = BigDecimal("0.000"), fractionDigits = 3, centAmount = 0, Euro)
+      (BigDecimal("0.015") EUR_PRECISE 3) % BigDecimal("0.002") must equal(
+        BigDecimal("0.001") EUR_PRECISE 3
       )
     }
 
     it("should support the binary '/%' operator.") {
-      HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro)./%(3.00) must equal(
-        (HighPrecisionMoney(amount = BigDecimal("3.000"), fractionDigits = 3, centAmount = 300, Euro),
-          HighPrecisionMoney(amount = BigDecimal("1.000"), fractionDigits = 3, centAmount = 100, Euro))
+      (BigDecimal("10.000") EUR_PRECISE 3)./%(3.00) must equal(
+        (BigDecimal("3.000") EUR_PRECISE 3, BigDecimal("1.000") EUR_PRECISE 3)
       )
     }
 
     it("should support the remainder operator.") {
-      HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro).remainder(3.00) must equal(
-        HighPrecisionMoney(amount = BigDecimal("1.000"), fractionDigits = 3, centAmount = 100, Euro))
+      (BigDecimal("10.000") EUR_PRECISE 3).remainder(3.00) must equal(BigDecimal("1.000") EUR_PRECISE 3)
 
-      HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro).remainder(
-        HighPrecisionMoney(amount = BigDecimal("3.000"), fractionDigits = 3, centAmount = 300, Euro)) must equal(
-          HighPrecisionMoney(amount = BigDecimal("1.000"), fractionDigits = 3, centAmount = 100, Euro))
+      (BigDecimal("10.000") EUR_PRECISE 3).remainder(BigDecimal("3.000") EUR_PRECISE 3) must equal(BigDecimal("1.000") EUR_PRECISE 3)
     }
 
     it("should partition the value properly.") {
-      val a = HighPrecisionMoney(amount = BigDecimal("10.000"), fractionDigits = 3, centAmount = 1000, Euro).partition(1, 2, 3) must equal(
+      (BigDecimal("10.000") EUR_PRECISE 3).partition(1, 2, 3) must equal(
         ArrayBuffer(
-          HighPrecisionMoney(amount = BigDecimal("1.667"), fractionDigits = 3, centAmount = 167, Euro),
-          HighPrecisionMoney(amount = BigDecimal("3.333"), fractionDigits = 3, centAmount = 333, Euro),
-          HighPrecisionMoney(amount = BigDecimal("5.000"), fractionDigits = 3, centAmount = 500, Euro)
+          BigDecimal("1.667") EUR_PRECISE 3,
+          BigDecimal("3.333") EUR_PRECISE 3,
+          BigDecimal("5.000") EUR_PRECISE 3
         )
       )
     }
-
-    //make constructors private, only use from centAmount, fromDecimalAmount
-
   }
 }

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -7,7 +7,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.postfixOps
 
 class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
-  import HighPrecisionMoney._
+  import HighPrecisionMoney.ImplicitsString._
+  import HighPrecisionMoney.ImplicitsStringPrecise._
 
   implicit val defaultRoundingMode = BigDecimal.RoundingMode.HALF_EVEN
 
@@ -16,7 +17,7 @@ class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
   describe("High Precision Money") {
 
     it("should allow creation of high precision money") {
-      (BigDecimal(0.01) EUR) must equal(BigDecimal(0.01) EUR)
+      ("0.01".EUR) must equal("0.01".EUR)
     }
 
     it("should not allow creation of high precision money without sufficient scale") {
@@ -29,98 +30,98 @@ class HighPrecisionMoneySpec extends FunSpec with MustMatchers {
 
     it("should not allow creation of high precision money with less fraction digits than the currency has") {
       val thrown = intercept[IllegalArgumentException] {
-        BigDecimal(0.01) EUR_PRECISE 1
+        "0.01" EUR_PRECISE 1
       }
 
       assert(thrown.getMessage == "requirement failed: `fractionDigits` should be  >= than the default fraction digits of the currency.")
     }
 
     it("should convert precise amount to long value correctly") {
-      (BigDecimal("0.0001") EUR_PRECISE 4).preciseAmountAsLong must equal (1)
+      ("0.0001" EUR_PRECISE 4).preciseAmountAsLong must equal (1)
     }
 
     it("should reduce fraction digits as expected") {
-      (BigDecimal("0.0001") EUR_PRECISE 4).withFractionDigits(2).preciseAmountAsLong must equal(0)
+      ("0.0001" EUR_PRECISE 4).withFractionDigits(2).preciseAmountAsLong must equal(0)
     }
 
     it("should support the unary '-' operator.") {
-      -(BigDecimal(0.01) EUR_PRECISE 2) must equal (BigDecimal(-0.01) EUR_PRECISE 2)
+      -("0.01" EUR_PRECISE 2) must equal ("-0.01" EUR_PRECISE 2)
     }
 
     it("should support the binary '+' operator.") {
-      (BigDecimal(0.001) EUR_PRECISE 3) + (BigDecimal(0.002) EUR_PRECISE 3) must equal(
-        BigDecimal(0.003) EUR_PRECISE 3
+      ("0.001" EUR_PRECISE 3) + ("0.002" EUR_PRECISE 3) must equal(
+        "0.003" EUR_PRECISE 3
       )
 
-      (BigDecimal(0.005) EUR_PRECISE 3) + Money(0.01, Euro) must equal(
-        BigDecimal(0.015) EUR_PRECISE 3
+      ("0.005" EUR_PRECISE 3) + Money.fromDecimalAmount(BigDecimal("0.01"), Euro) must equal(
+        "0.015" EUR_PRECISE 3
       )
 
-      (BigDecimal(0.005) EUR_PRECISE 3) + BigDecimal("0.005") must equal(
-        BigDecimal("0.010") EUR_PRECISE 3
+      ("0.005" EUR_PRECISE 3) + BigDecimal("0.005") must equal(
+        "0.010" EUR_PRECISE 3
       )
     }
 
     it("should support the binary '-' operator.") {
-      (BigDecimal(0.002) EUR_PRECISE 3) - (BigDecimal(0.001) EUR_PRECISE 3) must equal(
-        BigDecimal(0.001) EUR_PRECISE 3
+      ("0.002" EUR_PRECISE 3) - ("0.001" EUR_PRECISE 3) must equal(
+        "0.001" EUR_PRECISE 3
       )
 
-      (BigDecimal(0.015) EUR_PRECISE 3) - Money(0.01, Euro) must equal(
-        BigDecimal(0.005) EUR_PRECISE 3
+      ("0.015" EUR_PRECISE 3) - Money.fromDecimalAmount(BigDecimal("0.01"), Euro) must equal(
+        "0.005" EUR_PRECISE 3
       )
 
-      (BigDecimal(0.005) EUR_PRECISE 3) - BigDecimal("0.005") must equal(
-        BigDecimal(0.000) EUR_PRECISE 3
+      ("0.005" EUR_PRECISE 3) - BigDecimal("0.005") must equal(
+        "0.000" EUR_PRECISE 3
       )
     }
 
     it("should support the binary '*' operator.") {
-      (BigDecimal(0.002) EUR_PRECISE 3) * (BigDecimal("5.00") EUR_PRECISE 2) must equal(
-        BigDecimal("0.010") EUR_PRECISE 3
+      ("0.002" EUR_PRECISE 3) * ("5.00" EUR_PRECISE 2) must equal(
+        "0.010" EUR_PRECISE 3
       )
 
-      (BigDecimal(0.015) EUR_PRECISE 3) * Money(BigDecimal("100.00"), Euro) must equal(
-        BigDecimal("1.500") EUR_PRECISE 3
+      ("0.015" EUR_PRECISE 3) * Money.fromDecimalAmount(BigDecimal("100.00"), Euro) must equal(
+        "1.500" EUR_PRECISE 3
       )
 
-      (BigDecimal(0.005) EUR_PRECISE 3) * BigDecimal("0.005") must equal(
-        BigDecimal("0.000") EUR_PRECISE 3
+      ("0.005" EUR_PRECISE 3) * BigDecimal("0.005") must equal(
+        "0.000" EUR_PRECISE 3
       )
     }
 
     it("should support the binary '%' operator.") {
-      (BigDecimal("0.010") EUR_PRECISE 3) % (BigDecimal("5.00") EUR_PRECISE 2) must equal(
-        BigDecimal("0.010") EUR_PRECISE 3
+      ("0.010" EUR_PRECISE 3) % ("5.00" EUR_PRECISE 2) must equal(
+        "0.010" EUR_PRECISE 3
       )
 
-      (BigDecimal("100.000") EUR_PRECISE 3) % Money(BigDecimal("100.00"), Euro) must equal(
-        BigDecimal("0.000") EUR_PRECISE 3
+      ("100.000" EUR_PRECISE 3) % Money.fromDecimalAmount(BigDecimal("100.00"), Euro) must equal(
+        "0.000" EUR_PRECISE 3
       )
 
-      (BigDecimal("0.015") EUR_PRECISE 3) % BigDecimal("0.002") must equal(
-        BigDecimal("0.001") EUR_PRECISE 3
+      ("0.015" EUR_PRECISE 3) % BigDecimal("0.002") must equal(
+        "0.001" EUR_PRECISE 3
       )
     }
 
     it("should support the binary '/%' operator.") {
-      (BigDecimal("10.000") EUR_PRECISE 3)./%(3.00) must equal(
-        (BigDecimal("3.000") EUR_PRECISE 3, BigDecimal("1.000") EUR_PRECISE 3)
+      ("10.000" EUR_PRECISE 3)./%(3.00) must equal(
+        ("3.000" EUR_PRECISE 3, "1.000" EUR_PRECISE 3)
       )
     }
 
     it("should support the remainder operator.") {
-      (BigDecimal("10.000") EUR_PRECISE 3).remainder(3.00) must equal(BigDecimal("1.000") EUR_PRECISE 3)
+      ("10.000" EUR_PRECISE 3).remainder(3.00) must equal("1.000" EUR_PRECISE 3)
 
-      (BigDecimal("10.000") EUR_PRECISE 3).remainder(BigDecimal("3.000") EUR_PRECISE 3) must equal(BigDecimal("1.000") EUR_PRECISE 3)
+      ("10.000" EUR_PRECISE 3).remainder("3.000" EUR_PRECISE 3) must equal("1.000" EUR_PRECISE 3)
     }
 
     it("should partition the value properly.") {
-      (BigDecimal("10.000") EUR_PRECISE 3).partition(1, 2, 3) must equal(
+      ("10.000" EUR_PRECISE 3).partition(1, 2, 3) must equal(
         ArrayBuffer(
-          BigDecimal("1.667") EUR_PRECISE 3,
-          BigDecimal("3.333") EUR_PRECISE 3,
-          BigDecimal("5.000") EUR_PRECISE 3
+          "1.667" EUR_PRECISE 3,
+          "3.333" EUR_PRECISE 3,
+          "5.000" EUR_PRECISE 3
         )
       )
     }

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -8,6 +8,8 @@ import org.scalatest.MustMatchers
 class MoneySpec extends FunSpec with MustMatchers {
   import Money._
 
+  implicit val mode = BigDecimal.RoundingMode.UNNECESSARY
+
   describe("Money") {
     it("should have value semantics.") {
       (1.23 EUR) must equal (1.23 EUR)
@@ -32,8 +34,10 @@ class MoneySpec extends FunSpec with MustMatchers {
     }
 
     it("should not be prone to common rounding errors known from floating point numbers.") {
-      var m = 0.00 EUR;
+      var m = 0.00 EUR
+
       for (i <- 1 to 10) m = m + 0.10
+
       m must equal (1.00 EUR)
     }
 

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.FunSpec
 import org.scalatest.MustMatchers
 
 class MoneySpec extends FunSpec with MustMatchers {
+  import Money.ImplicitsDecimal._
   import Money._
 
   implicit val mode = BigDecimal.RoundingMode.UNNECESSARY
@@ -38,7 +39,7 @@ class MoneySpec extends FunSpec with MustMatchers {
     it("should not be prone to common rounding errors known from floating point numbers.") {
       var m = 0.00 EUR
 
-      for (i <- 1 to 10) m = m + 0.10
+      for (i ← 1 to 10) m = m + 0.10
 
       m must equal (1.00 EUR)
     }

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -15,7 +15,9 @@ class MoneySpec extends FunSpec with MustMatchers {
       (1.23 EUR) must equal (1.23 EUR)
     }
 
-    it("should default to HALF_EVEN rounding mode when using monetary notation.") {
+    it("should default to HALF_EVEN rounding mode when using monetary notation and use provided rounding mode when performing operations.") {
+      implicit val mode = BigDecimal.RoundingMode.HALF_EVEN
+
       (1.001 EUR) must equal (1.00 EUR)
       (1.005 EUR) must equal (1.00 EUR)
       (1.015 EUR) must equal (1.02 EUR)


### PR DESCRIPTION
@sphereio/backend please review

This might be a bit of an early PR, stuff still might change, but no harm in already starting the discussions.

### High precision money support

New trait was created `BaseMoney`, existing `Money` extends it. The type that will support the high precision money is `HighPrecisionMoney`, it also extends the `BaseMoney`.

Main idea is to keep the two types relatively compatible, so this is how the usual money looked like:
```
{
    "currencyCode": "USD",
    "centAmount": 2380
}
```
If this information would be sent by the client, it's treated as 'Money` i.e. the type is 'centAmount`, basically if the above provided JSON would be sent to server internally it would be treated as:
```
{
    "type": "centAmount",
    "currencyCode": "USD",
    "centAmount": 2380,
    "fractionDigits": 2
}
```

New format will be returned to the client and the clients should remain unaffected since `currencyCode` and `centAmount` are still there. Additional info is not expected to break the clients when returning this info as result. The same criteria also goes for `HighPrecisionMoney`:

```
{
    "type": "preciseAmount",
    "currencyCode": "EUR",
    "centAmount": 6,
    "preciseAmount": 550,
    "fractionDigits": 4
}
```

It still contains all the fields that the clients would expect on response. With time we'll have to think about how to introduce this logic in the client part.

Money as such had some places where rounding modes were implicitly set to `HALF_EVEN` when using the operations, all the operations on money (where it makes sense) now expose rounding mode as a implicit parameter.