### PR TITLE
Separate derive functions for toJson and fromJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.12 (2019-06-05)
+
+* Added derive functions for `ToJSON` and `FromJSON`. E.g. in addition to `jsonProduct`, there is now also `toJsonProduct` and `fromJsonProduct`.
+
 ## 0.9.11 (2019-06-04)
 
 * sphere-mongo depends on `mongodb-driver-core` instead of `mongodb-driver` to let the user decide to use whether the sync or the `mongodb-driver-async` driver.

--- a/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -30,10 +30,23 @@ package object generic {
   def deriveJSON[A]: JSON[A] = macro JSONMacros.deriveJSON_impl[A]
   def deriveSingletonJSON[A]: JSON[A] = macro JSONMacros.deriveSingletonJSON_impl[A]
 
-  /** Creates a JSON instance for an Enumeration type that encodes the `toString`
+  private def JSONofToAndFrom[A](toJSON: ToJSON[A], fromJSON: FromJSON[A]): JSON[A] = {
+    new JSON[A] {
+      def write(a: A): JValue = toJSON.write(a)
+      def read(jval: JValue): ValidatedNel[JSONError, A] = fromJSON.read(jval)
+      override def fields: Set[String] = fromJSON.fields
+    }
+  }
+
+  /** Creates a ToJSON instance for an Enumeration type that encodes the `toString`
     * representations of the enumeration values. */
-  def jsonEnum(e: Enumeration): JSON[e.Value] = new JSON[e.Value] {
+  def toJsonEnum(e: Enumeration): ToJSON[e.Value] = new ToJSON[e.Value] {
     def write(a: e.Value): JValue = JString(a.toString)
+  }
+
+  /** Creates a FromJSON instance for an Enumeration type that encodes the `toString`
+    * representations of the enumeration values. */
+  def fromJsonEnum(e: Enumeration): FromJSON[e.Value] = new FromJSON[e.Value] {
     def read(jval: JValue): ValidatedNel[JSONError, e.Value] = jval match {
       case JString(s) => e.values.find(_.toString == s).toValidNel(
         JSONParseError("Invalid enum value: '%s'. Expected one of: %s".format(s, e.values.mkString("','")))
@@ -42,13 +55,29 @@ package object generic {
     }
   }
 
-  /** Creates a JSON instance for a singleton object that encodes only the type value
-    * as a JSON string. */
-  def jsonSingleton[T](singleton: T): JSON[T] = {
+  /** Creates a JSON instance for an Enumeration type that encodes the `toString`
+    * representations of the enumeration values. */
+  def jsonEnum(e: Enumeration): JSON[e.Value] = JSONofToAndFrom(toJsonEnum(e), fromJsonEnum(e))
+
+  private def jsonSingletonTypeValue[T](singleton: T): String = {
     val clazz = singleton.getClass
-    val typeValue = getJSONClass(clazz).typeHint.map(_.value).getOrElse(defaultTypeValue(clazz))
-    new JSON[T] {
+    getJSONClass(clazz).typeHint.map(_.value).getOrElse(defaultTypeValue(clazz))
+  }
+
+  /** Creates a ToJSON instance for a singleton object that encodes only the type value
+    * as a JSON string. */
+  def toJsonSingleton[T](singleton: T): ToJSON[T] = {
+    val typeValue = jsonSingletonTypeValue(singleton)
+    new ToJSON[T] {
       def write(t: T): JValue = JString(typeValue)
+    }
+  }
+
+  /** Creates a FromJSON instance for a singleton object that encodes only the type value
+    * as a JSON string. */
+  def fromJsonSingleton[T](singleton: T): FromJSON[T] = {
+    val typeValue = jsonSingletonTypeValue(singleton)
+    new FromJSON[T] {
       def read(j: JValue): ValidatedNel[JSONError, T] = j match {
         case JString(`typeValue`) => Valid(singleton)
         case _ => jsonParseError("JSON string '" + typeValue + "' expected.")
@@ -56,14 +85,29 @@ package object generic {
     }
   }
 
-  /** Creates a JSON instance for a product type of arity 0 (case objects) that are part of a sum type. */
-  def jsonProduct0[T <: Product](singleton: T): JSON[T] = {
-    val (typeField, typeValue) = getJSONClass(singleton.getClass).typeHint match {
+  /** Creates a JSON instance for a singleton object that encodes only the type value
+    * as a JSON string. */
+  def jsonSingleton[T](singleton: T): JSON[T] = JSONofToAndFrom(toJsonSingleton(singleton), fromJsonSingleton(singleton))
+
+  private def jsonProduct0Type[T <: Product](singleton: T): (String, String) = {
+    getJSONClass(singleton.getClass).typeHint match {
       case Some(hint) => (hint.field, hint.value)
       case None => (defaultTypeFieldName, defaultTypeValue(singleton.getClass))
     }
-    new JSON[T] {
+  }
+
+  /** Creates a ToJSON instance for a product type of arity 0 (case objects) that are part of a sum type. */
+  def toJsonProduct0[T <: Product](singleton: T): ToJSON[T] = {
+    val (typeField, typeValue) = jsonProduct0Type(singleton)
+    new ToJSON[T] {
       def write(t: T): JValue = JObject(JField(typeField, JString(typeValue)) :: Nil)
+    }
+  }
+
+  /** Creates a FromJSON instance for a product type of arity 0 (case objects) that are part of a sum type. */
+  def fromJsonProduct0[T <: Product](singleton: T): FromJSON[T] = {
+    val (typeField, typeValue) = jsonProduct0Type(singleton)
+    new FromJSON[T] {
       def read(j: JValue): ValidatedNel[JSONError, T] = j match {
         case o: JObject => findTypeValue(o, typeField) match {
           case Some(t) => t match {
@@ -77,38 +121,130 @@ package object generic {
     }
   }
 
+  /** Creates a JSON instance for a product type of arity 0 (case objects) that are part of a sum type. */
+  def jsonProduct0[T <: Product](singleton: T): JSON[T] = JSONofToAndFrom(toJsonProduct0(singleton), fromJsonProduct0(singleton))
+
   <#list 1..22 as i>
   <#assign typeParams><#list 1..i as j>A${j}<#if i !=j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} : FromJSON : ToJSON<#if i !=j>,</#if></#list></#assign>
-  /** Creates a `JSON[T]` instance for a product type (case class) `T` of arity ${i}. */
-  def jsonProduct[T <: Product: ClassTag, ${implTypeParams}](
+  /** Creates a `ToJSON[T]` instance for a product type (case class) `T` of arity ${i}. */
+  def toJsonProduct[T <: Product: ClassTag, ${implTypeParams}](
     construct: (<#list 1..i as j>A${j}<#if i !=j>, </#if></#list>) => T
-  ): JSON[T] = {
+  ): ToJSON[T] = {
     val jsonClass = getJSONClass(classTag[T].runtimeClass)
     val _fields = jsonClass.fields
-    new JSON[T] {
+    new ToJSON[T] {
       def write(r: T): JValue = {
         val buf = new ListBuffer[JField]
         if (jsonClass.typeHint.isDefined) writeTypeField(jsonClass, buf)
         <#list 1..i as j>
-        writeField[A${j}](buf, _fields(${j-1}), r.productElement(${j-1}).asInstanceOf[A${j}])
+          writeField[A${j}](buf, _fields(${j-1}), r.productElement(${j-1}).asInstanceOf[A${j}])
         </#list>
         JObject(buf.toList)
       }
+    }
+  }
+  </#list>
+
+  <#list 1..22 as i>
+  <#assign typeParams><#list 1..i as j>A${j}<#if i !=j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} : FromJSON : ToJSON<#if i !=j>,</#if></#list></#assign>
+  /** Creates a `FromJSON[T]` instance for a product type (case class) `T` of arity ${i}. */
+  def fromJsonProduct[T <: Product: ClassTag, ${implTypeParams}](
+    construct: (<#list 1..i as j>A${j}<#if i !=j>, </#if></#list>) => T
+  ): FromJSON[T] = {
+    val jsonClass = getJSONClass(classTag[T].runtimeClass)
+    val _fields = jsonClass.fields
+    new FromJSON[T] {
       def read(jval: JValue): ValidatedNel[JSONError, T] = jval match {
         case o: JObject =>
           (readField[A1](_fields.head, o)<#if i!=1>
-            <#list 2..i as j>
-            , readField[A${j}](_fields(${j-1}), o)
-            </#list>
-          </#if>
-            ).map<#if i!=1>N</#if>(construct)
+          <#list 2..i as j>
+      , readField[A${j}](_fields(${j-1}), o)
+      </#list>
+      </#if>
+      ).map<#if i!=1>N</#if>(construct)
         case _ => jsonParseError("JSON object expected.")
       }
       override val fields = _fields.map(_.name).toSet
     }
   }
   </#list>
+
+  <#list 1..22 as i>
+  <#assign typeParams><#list 1..i as j>A${j}<#if i !=j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} : FromJSON : ToJSON<#if i !=j>,</#if></#list></#assign>
+  /** Creates a `JSON[T]` instance for a product type (case class) `T` of arity ${i}. */
+  def jsonProduct[T <: Product: ClassTag, ${implTypeParams}](
+    construct: (<#list 1..i as j>A${j}<#if i !=j>, </#if></#list>) => T
+  ): JSON[T] = JSONofToAndFrom(toJsonProduct(construct), fromJsonProduct(construct))
+  </#list>
+
+  /**
+    * Creates a `ToJSON[T]` instance for some supertype `T`. The instance acts as a type-switch between implementation which should be
+    * a singleton case objects.
+    *
+    * This can be used as an alternative to an enum.
+    */
+  def toJsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : ToJSON](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
+    val inSelectors: List[TypeSelectorToJSON[_]] = typeSelectorToJSON[A] :: selectors
+    val allSelectors = inSelectors.flatMap(s => s.serializer match {
+      case container: TypeSelectorToJSONContainer => container.typeSelectors :+ s
+      case _ => s :: Nil
+    })
+    val writeMapBuilder = Map.newBuilder[Class[_], TypeSelectorToJSON[_]]
+    allSelectors.foreach { s =>
+      writeMapBuilder += (s.clazz -> s)
+    }
+    val writeMap = writeMapBuilder.result
+
+    new ToJSON[T] with TypeSelectorToJSONContainer {
+      override def typeSelectors = allSelectors
+
+      def write(t: T): JValue = writeMap.get(t.getClass) match {
+        case Some(ts) =>
+          ts.write(t) match {
+            case s: JString => s
+            case j => throw new IllegalStateException("The json is not a string, but a " + j.getClass)
+          }
+
+        case None => throw new IllegalStateException("Can't find a serializer for a class " + t.getClass)
+      }
+    }
+  }
+
+  /**
+    * Creates a `FromJSON[T]` instance for some supertype `T`. The instance acts as a type-switch between implementation which should be
+    * a singleton case objects.
+    *
+    * This can be used as an alternative to an enum.
+    */
+  def fromJsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
+    val readMapBuilder = Map.newBuilder[String, TypeSelectorFromJSON[_]]
+    val inSelectors: List[TypeSelectorFromJSON[_]] = typeSelectorFromJSON[A] :: selectors
+    val allSelectors = inSelectors.flatMap(s => s.jsonr match {
+      case container: TypeSelectorFromJSONContainer => container.typeSelectors :+ s
+      case _ => s :: Nil
+    })
+    allSelectors.foreach { s =>
+      readMapBuilder += (s.typeValue -> s)
+    }
+    val readMap = readMapBuilder.result
+
+    new FromJSON[T] with TypeSelectorFromJSONContainer {
+      override def typeSelectors = allSelectors
+
+      def read(jval: JValue): ValidatedNel[JSONError, T] = jval match {
+        case s @ JString(typeName) =>
+          readMap.get(typeName) match {
+            case Some(ts) => ts.read(s).asInstanceOf[ValidatedNel[JSONError, T]]
+            case None => jsonParseError("Invalid value '" + typeName + "'.")
+          }
+
+        case _ => jsonParseError("JSON string expected.")
+      }
+    }
+  }
 
   /**
     * Creates a `JSON[T]` instance for some supertype `T`. The instance acts as a type-switch between implementation which should be
@@ -123,47 +259,29 @@ package object generic {
       case _ => s :: Nil
     })
 
-    val readMapBuilder = Map.newBuilder[String, TypeSelector[_]]
-    val writeMapBuilder = Map.newBuilder[Class[_], TypeSelector[_]]
-
-    allSelectors.foreach { s =>
-      readMapBuilder += (s.typeValue -> s)
-      writeMapBuilder += (s.clazz -> s)
-    }
-
-    val readMap = readMapBuilder.result
-    val writeMap = writeMapBuilder.result
-    val clazz = classTag[T].runtimeClass
-
-    val typeField = Option(clazz.getAnnotation(classOf[JSONTypeHintField])) match {
-      case Some(a) => a.value
-      case None => defaultTypeFieldName
-    }
+    val toJSON = toJsonSingletonEnumSwitch[T, A](selectors)
+    val fromJSON = fromJsonSingletonEnumSwitch[T, A](selectors)
 
     new JSON[T] with TypeSelectorContainer {
       override def typeSelectors: List[TypeSelector[_]] = allSelectors
 
-      def read(jval: JValue): ValidatedNel[JSONError, T] = jval match {
-        case s @ JString(typeName) =>
-          readMap.get(typeName) match {
-            case Some(ts) => ts.read(s).asInstanceOf[ValidatedNel[JSONError, T]]
-            case None => jsonParseError("Invalid value '" + typeName + "'.")
-          }
+      def read(jval: JValue): ValidatedNel[JSONError, T] = fromJSON.read(jval)
 
-        case _ => jsonParseError("JSON string expected.")
-      }
-
-      def write(t: T): JValue = writeMap.get(t.getClass) match {
-        case Some(ts) =>
-          ts.write(t) match {
-            case s: JString => s
-            case j => throw new IllegalStateException("The json is not a string, but a " + j.getClass)
-          }
-
-        case None => throw new IllegalStateException("Can't find a serializer for a class " + t.getClass)
-      }
+      def write(t: T): JValue = toJSON.write(t)
     }
   }
+
+  <#list 2..20 as i>
+  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
+  def toJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}] :: selectors)
+  </#list>
+
+  <#list 2..20 as i>
+  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
+  def fromJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}] :: selectors)
+  </#list>
 
   <#list 2..20 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
@@ -171,47 +289,26 @@ package object generic {
   def jsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonSingletonEnumSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
   </#list>
 
-  /** Creates a `JSON[T]` instance for some supertype `T`. The instance acts as a type-switch
+  /** Creates a `ToJSON[T]` instance for some supertype `T`. The instance acts as a type-switch
     * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
     * on a field that acts as a type hint. */
-  def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON, A2 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
-    val inSelectors = typeSelector[A1] :: typeSelector[A2] :: selectors
+  def toJsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: ToJSON, A2 <: T: ClassTag: ToJSON](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
+    val inSelectors = typeSelectorToJSON[A1] :: typeSelectorToJSON[A2] :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
-      case container: TypeSelectorContainer => container.typeSelectors :+ s
+      case container: TypeSelectorToJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
 
-    val readMapBuilder = Map.newBuilder[String, TypeSelector[_]]
-    val writeMapBuilder = Map.newBuilder[Class[_], TypeSelector[_]]
+    val writeMapBuilder = Map.newBuilder[Class[_], TypeSelectorToJSON[_]]
 
     allSelectors.foreach { s =>
-      readMapBuilder += (s.typeValue -> s)
       writeMapBuilder += (s.clazz -> s)
     }
 
-    val readMap = readMapBuilder.result
     val writeMap = writeMapBuilder.result
-    val clazz = classTag[T].runtimeClass
 
-    val typeField = Option(clazz.getAnnotation(classOf[JSONTypeHintField])) match {
-      case Some(a) => a.value
-      case None => defaultTypeFieldName
-    }
-
-    new JSON[T] with TypeSelectorContainer {
-      override def typeSelectors: List[TypeSelector[_]] = allSelectors
-
-      def read(jval: JValue): ValidatedNel[JSONError, T] = jval match {
-        case o: JObject =>
-          findTypeValue(o, typeField) match {
-            case Some(t) => readMap.get(t) match {
-              case Some(ts) => ts.read(o).asInstanceOf[ValidatedNel[JSONError, T]]
-              case None => jsonParseError("Invalid type value '" + t + "' in '%s'".format(compactJson(o)))
-            }
-            case None => jsonParseError("Missing type field '" + typeField + "' in '%s'".format(compactJson(o)))
-          }
-        case _ => jsonParseError("JSON object expected.")
-      }
+    new ToJSON[T] with TypeSelectorToJSONContainer {
+      override def typeSelectors: List[TypeSelectorToJSON[_]] = allSelectors
 
       def write(t: T): JValue = writeMap.get(t.getClass) match {
         case Some(ts) =>
@@ -226,17 +323,142 @@ package object generic {
     }
   }
 
+  /** Creates a `FromJSON[T]` instance for some supertype `T`. The instance acts as a type-switch
+    * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
+    * on a field that acts as a type hint. */
+  def fromJsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON, A2 <: T: ClassTag: FromJSON](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
+    val inSelectors = typeSelectorFromJSON[A1] :: typeSelectorFromJSON[A2] :: selectors
+    val allSelectors = inSelectors.flatMap(s => s.jsonr match {
+      case container: TypeSelectorFromJSONContainer => container.typeSelectors :+ s
+      case _ => s :: Nil
+    })
+
+    val readMapBuilder = Map.newBuilder[String, TypeSelectorFromJSON[_]]
+
+    allSelectors.foreach { s =>
+      readMapBuilder += (s.typeValue -> s)
+    }
+
+    val readMap = readMapBuilder.result
+    val clazz = classTag[T].runtimeClass
+
+    val typeField = Option(clazz.getAnnotation(classOf[JSONTypeHintField])) match {
+      case Some(a) => a.value
+      case None => defaultTypeFieldName
+    }
+
+    new FromJSON[T] with TypeSelectorFromJSONContainer {
+      override def typeSelectors: List[TypeSelectorFromJSON[_]] = allSelectors
+
+      def read(jval: JValue): ValidatedNel[JSONError, T] = jval match {
+        case o: JObject =>
+          findTypeValue(o, typeField) match {
+            case Some(t) => readMap.get(t) match {
+              case Some(ts) => ts.read(o).asInstanceOf[ValidatedNel[JSONError, T]]
+              case None => jsonParseError("Invalid type value '" + t + "' in '%s'".format(compactJson(o)))
+            }
+            case None => jsonParseError("Missing type field '" + typeField + "' in '%s'".format(compactJson(o)))
+          }
+        case _ => jsonParseError("JSON object expected.")
+      }
+    }
+  }
+
+  /** Creates a `JSON[T]` instance for some supertype `T`. The instance acts as a type-switch
+    * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
+    * on a field that acts as a type hint. */
+  def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON, A2 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
+    val inSelectors = typeSelector[A1] :: typeSelector[A2] :: selectors
+    val allSelectors = inSelectors.flatMap(s => s.serializer match {
+      case container: TypeSelectorContainer => container.typeSelectors :+ s
+      case _ => s :: Nil
+    })
+
+    val toJSON = toJsonTypeSwitch[T, A1, A2](selectors)
+    val fromJSON = fromJsonTypeSwitch[T, A1, A2](selectors)
+
+    new JSON[T] with TypeSelectorContainer {
+      override def typeSelectors: List[TypeSelector[_]] = allSelectors
+
+      def read(jval: JValue): ValidatedNel[JSONError, T] = fromJSON.read(jval)
+
+      def write(t: T): JValue = toJSON.write(t)
+    }
+  }
+
+  <#list 3..84 as i>
+  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
+  def toJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonTypeSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}] :: selectors)
+  </#list>
+
+  <#list 3..84 as i>
+  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
+  def fromJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonTypeSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}] :: selectors)
+  </#list>
+
   <#list 3..84 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
   def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
   </#list>
 
-  trait TypeSelectorContainer {
+  trait TypeSelectorBase {
+    def typeField: String
+    def typeValue: String
+    def clazz: Class[_]
+  }
+
+  trait TypeSelectorToJSONContainer {
+    def typeSelectors: List[TypeSelectorToJSON[_]]
+  }
+
+  trait TypeSelectorToJSON[A] extends TypeSelectorBase {
+    def write(a: Any): JValue
+    def serializer: ToJSON[A]
+  }
+
+  final class TypeSelectorToJSONImpl[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])(implicit val serializer: ToJSON[A]) extends TypeSelectorToJSON[A] {
+    def write(a: Any): JValue = toJValue(a.asInstanceOf[A])
+  }
+
+  private def typeSelectorToJSON[A: ClassTag: ToJSON](): TypeSelectorToJSON[_] = {
+    val clazz = classTag[A].runtimeClass
+    val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
+      case Some(hint) => (hint.field, hint.value)
+      case None => (defaultTypeFieldName, defaultTypeValue(clazz))
+    }
+    new TypeSelectorToJSONImpl[A](typeField, typeValue, clazz)
+  }
+
+  trait TypeSelectorFromJSONContainer {
+    def typeSelectors: List[TypeSelectorFromJSON[_]]
+  }
+
+  trait TypeSelectorFromJSON[A] extends TypeSelectorBase {
+    def read(o: JValue): ValidatedNel[JSONError, A]
+    def jsonr: FromJSON[A]
+  }
+
+  final class TypeSelectorFromJSONImpl[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])(implicit val jsonr: FromJSON[A]) extends TypeSelectorFromJSON[A] {
+    def read(o: JValue): ValidatedNel[JSONError, A] = fromJValue[A](o)
+  }
+
+  private def typeSelectorFromJSON[A: ClassTag: FromJSON](): TypeSelectorFromJSON[_] = {
+    val clazz = classTag[A].runtimeClass
+    val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
+      case Some(hint) => (hint.field, hint.value)
+      case None => (defaultTypeFieldName, defaultTypeValue(clazz))
+    }
+    new TypeSelectorFromJSONImpl[A](typeField, typeValue, clazz)
+  }
+
+  trait TypeSelectorContainer extends TypeSelectorFromJSONContainer with TypeSelectorToJSONContainer {
     def typeSelectors: List[TypeSelector[_]]
   }
 
-  final class TypeSelector[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])(implicit jsonr: FromJSON[A], val serializer: ToJSON[A]) {
+  final class TypeSelector[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])(implicit val jsonr: FromJSON[A], val serializer: ToJSON[A]) extends TypeSelectorFromJSON[A] with TypeSelectorToJSON[A] {
     def read(o: JValue): ValidatedNel[JSONError, A] = fromJValue[A](o)
     def write(a: Any): JValue = toJValue(a.asInstanceOf[A])
   }

--- a/json/src/test/scala/io/sphere/json/JSONSpec.scala
+++ b/json/src/test/scala/io/sphere/json/JSONSpec.scala
@@ -184,22 +184,134 @@ class JSONSpec extends FunSpec with MustMatchers {
     }
 
     it("must handle subclasses correctly in `jsonTypeSwitch`") {
-        val testSubjects = List[TestSubjectBase](
-          TestSubjectConcrete1("testSubject1"),
-          TestSubjectConcrete2("testSubject2"),
-          TestSubjectConcrete3("testSubject3"),
-          TestSubjectConcrete4("testSubject4")
-        )
+      implicit val jsonImpl = TestSubjectBase.json
 
-        testSubjects foreach (testSubject => {
-          val json = toJSON(testSubject)
-          withClue(json) {
-            fromJSON[TestSubjectBase](json) must equal (Valid(testSubject))
-          }
-        })
+      val testSubjects = List[TestSubjectBase](
+        TestSubjectConcrete1("testSubject1"),
+        TestSubjectConcrete2("testSubject2"),
+        TestSubjectConcrete3("testSubject3"),
+        TestSubjectConcrete4("testSubject4")
+      )
+
+      testSubjects foreach (testSubject => {
+        val json = toJSON(testSubject)
+        withClue(json) {
+          fromJSON[TestSubjectBase](json) must equal (Valid(testSubject))
+        }
+      })
 
     }
 
+  }
+
+  describe("ToJSON and FromJSON") {
+    it("must provide derived JSON instances for sum types") {
+      // ToJSON
+      implicit val birdToJSON = toJsonProduct(Bird.apply _)
+      implicit val dogToJSON = toJsonProduct(Dog.apply _)
+      implicit val catToJSON = toJsonProduct(Cat.apply _)
+      implicit val animalToJSON = toJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
+      // FromJSON
+      implicit val birdFromJSON = fromJsonProduct(Bird.apply _)
+      implicit val dogFromJSON = fromJsonProduct(Dog.apply _)
+      implicit val catFromJSON = fromJsonProduct(Cat.apply _)
+      implicit val animalFromJSON = fromJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
+
+      List(Bird("Peewee"), Dog("Hasso"), Cat("Felidae")) foreach { a: Animal =>
+        fromJSON[Animal](toJSON(a)) must equal (Valid(a))
+      }
+    }
+
+    it("must provide derived instances for product types with concrete type parameters") {
+      implicit val aToJSON = toJsonProduct(GenericA.apply[String] _)
+      implicit val aFromJSON = fromJsonProduct(GenericA.apply[String] _)
+      val a = GenericA("hello")
+      fromJSON[GenericA[String]](toJSON(a)) must equal (Valid(a))
+    }
+
+    it("must provide derived instances for singleton objects") {
+      implicit val toSingletonJSON = toJsonSingleton(Singleton)
+      implicit val fromSingletonJSON = fromJsonSingleton(Singleton)
+      val json = s"""[${toJSON(Singleton)}]"""
+      withClue(json) {
+        fromJSON[Seq[Singleton.type]](json) must equal(Valid(Seq(Singleton)))
+      }
+
+      // ToJSON
+      implicit val toSingleAJSON = toJsonSingleton(SingletonA)
+      implicit val toSingleBJSON = toJsonSingleton(SingletonB)
+      implicit val toSingleCJSON = toJsonSingleton(SingletonC)
+      implicit val toSingleEnumJSON = toJsonSingletonEnumSwitch[SingletonEnum, SingletonA.type, SingletonB.type, SingletonC.type](Nil)
+      // FromJSON
+      implicit val fromSingleAJSON = fromJsonSingleton(SingletonA)
+      implicit val fromSingleBJSON = fromJsonSingleton(SingletonB)
+      implicit val fromSingleCJSON = fromJsonSingleton(SingletonC)
+      implicit val fromSingleEnumJSON = fromJsonSingletonEnumSwitch[SingletonEnum, SingletonA.type, SingletonB.type, SingletonC.type](Nil)
+
+      List(SingletonA, SingletonB, SingletonC) foreach { s: SingletonEnum =>
+        fromJSON[SingletonEnum](toJSON(s)) must equal (Valid(s))
+      }
+    }
+
+    it("must provide derived instances for sum types with a mix of case class / object") {
+      // ToJSON
+      implicit val toSingleJSON = toJsonProduct0(SingletonMixed)
+      implicit val toRecordJSON = toJsonProduct(RecordMixed.apply _)
+      implicit val toMixedJSON = toJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
+      // FromJSON
+      implicit val fromSingleJSON = fromJsonProduct0(SingletonMixed)
+      implicit val fromRecordJSON = fromJsonProduct(RecordMixed.apply _)
+      implicit val fromMixedJSON = fromJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
+      List(SingletonMixed, RecordMixed(1)) foreach { m: Mixed =>
+        fromJSON[Mixed](toJSON(m)) must equal (Valid(m))
+      }
+    }
+
+    it("must provide derived instances for scala.Enumeration") {
+      implicit val toScalaEnumJSON = toJsonEnum(ScalaEnum)
+      implicit val fromScalaEnumJSON = fromJsonEnum(ScalaEnum)
+      ScalaEnum.values.foreach { v =>
+        val json = s"""[${toJSON(v)}]"""
+        withClue(json) {
+          fromJSON[Seq[ScalaEnum.Value]](json) must equal(Valid(Seq(v)))
+        }
+      }
+    }
+
+    it("must handle subclasses correctly in `jsonTypeSwitch`") {
+      // ToJSON
+      implicit val to1 = toJsonProduct(TestSubjectConcrete1.apply _)
+      implicit val to2 = toJsonProduct(TestSubjectConcrete2.apply _)
+      implicit val to3 = toJsonProduct(TestSubjectConcrete3.apply _)
+      implicit val to4 = toJsonProduct(TestSubjectConcrete4.apply _)
+      implicit val toA = toJsonTypeSwitch[TestSubjectCategoryA, TestSubjectConcrete1, TestSubjectConcrete2](Nil)
+      implicit val toB = toJsonTypeSwitch[TestSubjectCategoryB, TestSubjectConcrete3, TestSubjectConcrete4](Nil)
+      implicit val toBase = toJsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
+
+      // FromJSON
+      implicit val from1 = fromJsonProduct(TestSubjectConcrete1.apply _)
+      implicit val from2 = fromJsonProduct(TestSubjectConcrete2.apply _)
+      implicit val from3 = fromJsonProduct(TestSubjectConcrete3.apply _)
+      implicit val from4 = fromJsonProduct(TestSubjectConcrete4.apply _)
+      implicit val fromA = fromJsonTypeSwitch[TestSubjectCategoryA, TestSubjectConcrete1, TestSubjectConcrete2](Nil)
+      implicit val fromB = fromJsonTypeSwitch[TestSubjectCategoryB, TestSubjectConcrete3, TestSubjectConcrete4](Nil)
+      implicit val fromBase = fromJsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
+
+      val testSubjects = List[TestSubjectBase](
+        TestSubjectConcrete1("testSubject1"),
+        TestSubjectConcrete2("testSubject2"),
+        TestSubjectConcrete3("testSubject3"),
+        TestSubjectConcrete4("testSubject4")
+      )
+
+      testSubjects foreach (testSubject => {
+        val json = toJSON(testSubject)
+        withClue(json) {
+          fromJSON[TestSubjectBase](json) must equal (Valid(testSubject))
+        }
+      })
+
+    }
   }
 }
 
@@ -216,14 +328,18 @@ case class TestSubjectConcrete3(c3: String) extends TestSubjectCategoryB
 case class TestSubjectConcrete4(c4: String) extends TestSubjectCategoryB
 
 object TestSubjectCategoryA {
-  implicit val json: JSON[TestSubjectCategoryA] = deriveJSON[TestSubjectCategoryA]
+  val json: JSON[TestSubjectCategoryA] = deriveJSON[TestSubjectCategoryA]
 }
 
 object TestSubjectCategoryB {
-  implicit val json: JSON[TestSubjectCategoryB] = deriveJSON[TestSubjectCategoryB]
+  val json: JSON[TestSubjectCategoryB] = deriveJSON[TestSubjectCategoryB]
 }
 
 object TestSubjectBase {
-  implicit val json: JSON[TestSubjectBase] =
+  val json: JSON[TestSubjectBase] = {
+    implicit val jsonA = TestSubjectCategoryA.json
+    implicit val jsonB = TestSubjectCategoryB.json
+
     jsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
+  }
 }


### PR DESCRIPTION
This PR introduces separate functions to derive `ToJSON` or `FromJSON` instances.

The final `JSON` is a composition of the result of calling the two separate functions now. This reuses some code, but the downside is that in some cases, we have to perform some intermediary computations twice.

The "new" tests are copied from `JSONSpecs`, the difference is that the `ToJSON` and `FromJSON` instances are derived separately.

In a future PR, we can also add support in the macros to, e.g. add `JSONMacros.deriveToJSON_impl` or `ToJSONMacros.deriveToJSON_impl`

@sphereio/backend please review