### PR TITLE
Fix generated signature of toJsonProduct and fromJsonProduct

### DIFF
--- a/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -126,7 +126,7 @@ package object generic {
 
   <#list 1..22 as i>
   <#assign typeParams><#list 1..i as j>A${j}<#if i !=j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} : FromJSON : ToJSON<#if i !=j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} : ToJSON<#if i !=j>,</#if></#list></#assign>
   /** Creates a `ToJSON[T]` instance for a product type (case class) `T` of arity ${i}. */
   def toJsonProduct[T <: Product: ClassTag, ${implTypeParams}](
     construct: (<#list 1..i as j>A${j}<#if i !=j>, </#if></#list>) => T
@@ -148,7 +148,7 @@ package object generic {
 
   <#list 1..22 as i>
   <#assign typeParams><#list 1..i as j>A${j}<#if i !=j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} : FromJSON : ToJSON<#if i !=j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} : FromJSON<#if i !=j>,</#if></#list></#assign>
   /** Creates a `FromJSON[T]` instance for a product type (case class) `T` of arity ${i}. */
   def fromJsonProduct[T <: Product: ClassTag, ${implTypeParams}](
     construct: (<#list 1..i as j>A${j}<#if i !=j>, </#if></#list>) => T

--- a/json/src/test/scala/io/sphere/json/JSONSpec.scala
+++ b/json/src/test/scala/io/sphere/json/JSONSpec.scala
@@ -312,6 +312,19 @@ class JSONSpec extends FunSpec with MustMatchers {
       })
 
     }
+
+    it("must provide derived JSON instances for product types (case classes)") {
+      import JSONSpec.{ Project, Milestone }
+      // ToJSON
+      implicit val milestoneToJSON = toJsonProduct(Milestone.apply _)
+      implicit val projectToJSON = toJsonProduct(Project.apply _)
+      // FromJSON
+      implicit val milestoneFromJSON = fromJsonProduct(Milestone.apply _)
+      implicit val projectFromJSON = fromJsonProduct(Project.apply _)
+
+      val proj = Project(42, "Linux", 7, Milestone("1.0") :: Milestone("2.0") :: Milestone("3.0") :: Nil)
+      fromJSON[Project](toJSON(proj)) must equal (Valid(proj))
+    }
   }
 }
 


### PR DESCRIPTION
🤦‍♂️ 

I missed to port one test in https://github.com/sphereio/sphere-scala-libs/pull/39 (it was somewhat hidden between tests that checked errors returned by `FromJSON` instances)... and of course that is where I had a bug hiding.

The generated signature for `toJsonProduct` still included `FromJSON` (and vice versa).

@sphereio/backend please review