### PR TITLE
respecting the java embedded annotation

### DIFF
--- a/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -523,7 +523,7 @@ package object generic {
     Reflect.getCaseClassMeta(clazz).fields.map { fm =>
       val m = clazz.getDeclaredMethod(fm.name)
       val name = Option(m.getAnnotation(classOf[JSONKey])).map(_.value).getOrElse(fm.name)
-      val embedded = m.isAnnotationPresent(classOf[JSONEmbedded])
+      val embedded = m.isAnnotationPresent(classOf[JSONEmbedded]) || m.isAnnotationPresent(classOf[io.sphere.json.annotations.JSONEmbedded])
       val ignored = m.isAnnotationPresent(classOf[JSONIgnore])
       if (ignored && fm.default.isEmpty) {
         // programmer error

--- a/json/src/test/scala/io/sphere/json/JSONEmbeddedSpec.scala
+++ b/json/src/test/scala/io/sphere/json/JSONEmbeddedSpec.scala
@@ -27,6 +27,17 @@ object JSONEmbeddedSpec {
     implicit val json: JSON[Test2] = jsonProduct(apply _)
   }
 
+  case class Test3(
+    name:String,
+    @JSONEmbedded
+    // @io.sphere.json.annotations.JSONEmbedded()
+    embedded: Embedded
+  )
+
+  object Test3 {
+    implicit val json: JSON[Test3] = jsonProduct(apply _)
+  }
+
 }
 
 class JSONEmbeddedSpec extends WordSpec with MustMatchers with OptionValues {
@@ -75,6 +86,23 @@ class JSONEmbeddedSpec extends WordSpec with MustMatchers with OptionValues {
       test2.embedded.value.value2 mustEqual 45
 
       val result = toJSON(test2)
+      parseJSON(result) mustEqual parseJSON(json)
+    }
+
+    "support embedded attribute with java annotation" in {
+      val json =
+        """{
+          |  "name": "ze name",
+          |  "value1": "ze value1",
+          |  "value2": 45
+          |}
+        """.stripMargin
+      val test3 = getFromJSON[Test3](json)
+      test3.name mustEqual "ze name"
+      test3.embedded.value1 mustEqual "ze value1"
+      test3.embedded.value2 mustEqual 45
+
+      val result = toJSON(test3)
       parseJSON(result) mustEqual parseJSON(json)
     }
 


### PR DESCRIPTION
The PR would allow to use JSONEmbedded annotation on fields directly from Java class.
At the moment it's possible to accidentally import an incorrect Java JSONEmbedded annotation that would have no effect on a field. 