### PR TITLE
make log value protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+## 0.9.16-SNAPSHOT
+
+* make value `log` of `Logging` protected. [60](https://github.com/sphereio/sphere-scala-libs/pull/60)
 
 ## 0.9.15 (2018-10-02)
 

--- a/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -10,14 +10,14 @@ import scala.annotation.meta.getter
 import scala.collection.mutable.ListBuffer
 import scala.language.experimental.macros
 import scala.reflect.{ClassTag, classTag}
-import io.sphere.util.{Memoizer, Reflect}
+import io.sphere.util.{Logging, Memoizer, Reflect}
 import org.json4s.JsonAST._
 import org.json4s.jackson.compactJson
 import org.json4s.JsonDSL._
 
 /** The generic package provides generic functions for deriving JSON instances via
   * some runtime & compile-time reflection. */
-package object generic {
+package object generic extends Logging {
   // Type aliases for more convenient use of the annotations in Scala code
   type JSONEmbedded = io.sphere.json.annotations.JSONEmbedded @getter
   type JSONKey = io.sphere.json.annotations.JSONKey @getter

--- a/util/src/main/scala/Logging.scala
+++ b/util/src/main/scala/Logging.scala
@@ -1,5 +1,5 @@
 package io.sphere.util
 
 trait Logging extends com.typesafe.scalalogging.StrictLogging {
-  val log = logger
+  protected val log = logger
 }


### PR DESCRIPTION
I suggest to make the `log` field protected otherwise it could happen that other classes accidentally reuse the log field as in the following example:

```scala
import io.sphere.json._ //the package object json extends Logging

class Foo {
  log.info("message")//logs as io.sphere.json.package$ instead of Foo
}
```