### PR TITLE
scalatest 3.0.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ lazy val standardSettings = Defaults.coreDefaultSettings ++ publishSettings ++ S
   javacOptions ++= Seq("-deprecation", "-Xlint:unchecked", "-source", "1.7", "-target", "1.7"),
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.0.5" % Test,
-    "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
+    "org.scalatest" %% "scalatest" % "3.0.7" % Test,
+    "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
     "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
   ),
   shellPrompt in ThisBuild := { state ⇒

--- a/mongo/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
+++ b/mongo/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
@@ -5,8 +5,8 @@ import io.sphere.mongo.generic._
 import org.bson.BasicBSONObject
 import org.bson.types.BasicBSONList
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.collection.JavaConverters._
 
@@ -17,7 +17,7 @@ object DefaultMongoFormatsTest {
   }
 }
 
-class DefaultMongoFormatsTest extends WordSpec with MustMatchers with GeneratorDrivenPropertyChecks {
+class DefaultMongoFormatsTest extends WordSpec with MustMatchers with ScalaCheckDrivenPropertyChecks {
   import DefaultMongoFormatsTest._
 
   "DefaultMongoFormats" must {

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -4,12 +4,12 @@ import java.util.Currency
 
 import cats.data.Validated.Invalid
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.collection.mutable.ArrayBuffer
 import scala.language.postfixOps
 
-class HighPrecisionMoneySpec extends FunSpec with MustMatchers with GeneratorDrivenPropertyChecks {
+class HighPrecisionMoneySpec extends FunSpec with MustMatchers with ScalaCheckDrivenPropertyChecks {
   import HighPrecisionMoney.ImplicitsString._
   import HighPrecisionMoney.ImplicitsStringPrecise._
 

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -1,11 +1,11 @@
 package io.sphere.util
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.language.postfixOps
 
-class MoneySpec extends FunSpec with MustMatchers with GeneratorDrivenPropertyChecks {
+class MoneySpec extends FunSpec with MustMatchers with ScalaCheckDrivenPropertyChecks {
   import Money.ImplicitsDecimal._
   import Money._
 


### PR DESCRIPTION
update scalacheck to 1.14.0 as compatible since https://github.com/scalatest/scalatest/releases/tag/release-3.0.6
https://github.com/scalatest/scalatest/releases/tag/release-3.0.7
https://github.com/rickynils/scalacheck/blob/1.14.0/RELEASE.markdown