### PR TITLE
java.util.Locale mongo format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.9.26-SNAPSHOT
 
+- introduce mongo format for java.util.Local
+
 ## 0.9.25 (2019-03-23)
 
 - artifacts for scala 2.13.0-M5 available. [95](https://github.com/sphereio/sphere-scala-libs/pull/95) and [96](https://github.com/sphereio/sphere-scala-libs/pull/96)

--- a/mongo/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
+++ b/mongo/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
@@ -1,7 +1,9 @@
 package io.sphere.mongo.format
 
+import java.util.Locale
 import io.sphere.mongo.format.DefaultMongoFormats._
 import io.sphere.mongo.generic._
+import io.sphere.util.LangTag
 import org.bson.BasicBSONObject
 import org.bson.types.BasicBSONList
 import org.scalacheck.Gen
@@ -87,6 +89,12 @@ class DefaultMongoFormatsTest extends WordSpec with MustMatchers with ScalaCheck
 
       check(map, format)
     }
+
+    "support Java Locale" in {
+      Locale.getAvailableLocales.filter(_.toLanguageTag != LangTag.UNDEFINED).foreach{ l: Locale =>
+        localeFormat.fromMongoValue(localeFormat.toMongoValue(l)).toLanguageTag must be (l.toLanguageTag)
+      }
+    }
   }
 
   private def check[A](gen: Gen[A], format: MongoFormat[A]) = {
@@ -96,5 +104,4 @@ class DefaultMongoFormatsTest extends WordSpec with MustMatchers with ScalaCheck
       result must be (value)
     }
   }
-
 }

--- a/util/src/main/scala/LangTag.scala
+++ b/util/src/main/scala/LangTag.scala
@@ -4,9 +4,12 @@ import java.util.Locale
 
 /** Extractor for Locales, e.g. for use in pattern-matching request paths. */
 object LangTag {
+
+  final val UNDEFINED: String = "und"
+
   class LocaleOpt(val locale: Locale) extends AnyVal {
     // if toLanguageTag returns "und", it means the language tag is undefined
-    def isEmpty: Boolean = "und" == locale.toLanguageTag
+    def isEmpty: Boolean = UNDEFINED == locale.toLanguageTag
     def get: Locale = locale
   }
 


### PR DESCRIPTION
Java Locale mongo format was introduced. It uses the same transformation logic as we use right now in the JSON formatter.