### PR TITLE
precompute most common centFactor in Money fromCentAmount

### DIFF
--- a/benchmarks/src/main/scala/json/FromJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromJsonBenchmark.scala
@@ -16,14 +16,14 @@ class FromJsonBenchmark {
 *** scala 2.12 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
 FromJsonBenchmark.listReader                  thrpt   10   65,643 ± 1,436  ops/s
-FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   13,785 ± 0,206  ops/s
+FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   51,019 ± 0,840  ops/s
 FromJsonBenchmark.seqReader                   thrpt   10   68,488 ± 1,299  ops/s
 FromJsonBenchmark.vectorReader                thrpt   10   70,445 ± 0,850  ops/s
 
 *** scala 2.13 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
 FromJsonBenchmark.listReader                  thrpt   10   63,963 ± 1,789  ops/s
-FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   14,135 ± 0,137  ops/s
+FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   54,781 ± 0,496  ops/s
 FromJsonBenchmark.seqReader                   thrpt   10   69,365 ± 1,275  ops/s
 FromJsonBenchmark.vectorReader                thrpt   10   70,401 ± 1,839  ops/s
    */

--- a/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
@@ -15,11 +15,11 @@ jmh:run
 
 *** scala 2.12 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
-FromMongoBenchmark.mongoValueToCaseClass      thrpt   10   17,454 ± 0,091  ops/s
+FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  292,099 ± 6,138  ops/s
 
 *** scala 2.13 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
-FromMongoBenchmark.mongoValueToCaseClass      thrpt   10   17,406 ± 0,433  ops/s
+FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  322,000 ± 7,792  ops/s
  */
 
   @Benchmark

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -267,6 +267,7 @@ object Money {
         case 1 => centFactorOneFractionDigit
         case 2 => centFactorTwoFractionDigit
         case 3 => centFactorThreeFractionDigit
+        case other => bdOne / bdTen.pow(other)
       }
     val amount = BigDecimal(centAmount) * centFactor
 


### PR DESCRIPTION
Following https://github.com/sphereio/sphere-scala-libs/pull/169 I was quite frustrated so I decided to look at the internals seriously.

I have generated the `Flight Recorder` file from our serialization benchmark and I found out that we spend most of our time recomputing the same `BigDecimal` for the `centFactor` of our `Price` object.

I decided to pre-compute the most common values and it works great 🚀 
This should definitely have an impact at scale.

@sphereio/backend Please review