### PR TITLE
Cleanup JavacOptions regarding Java7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val standardSettings = Defaults.coreDefaultSettings ++ publishSettings ++ S
     "-unchecked",
     "-feature"
   ),
-  javacOptions ++= Seq("-deprecation", "-Xlint:unchecked", "-source", "1.7", "-target", "1.7"),
+  javacOptions ++= Seq("-deprecation", "-Xlint:unchecked"),
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.1.1" % Test,


### PR DESCRIPTION
```
[warn] bootstrap class path not set in conjunction with -source 7
[warn] source value 7 is obsolete and will be removed in a future release
[warn] target value 7 is obsolete and will be removed in a future release
```

I do not know why it was necessary in first place