### PR TITLE
Allocate only once the typeHint JField

### DIFF
--- a/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -133,11 +133,9 @@ package object generic extends Logging {
   ): ToJSON[T] = {
     val jsonClass = getJSONClass(classTag[T].runtimeClass)
     val _fields = jsonClass.fields
-    val hintField: JField = {
-      if (jsonClass.typeHint.isDefined) {
-        val th = jsonClass.typeHint.get
-        JField(th.field, JString(th.value))
-      } else null
+    val hintField: JField = jsonClass.typeHint match {
+      case Some(th) => JField(th.field, JString(th.value))
+      case None => null  
     }
     new ToJSON[T] {
       def write(r: T): JValue = {


### PR DESCRIPTION
Setting to null is not so clean but this code is rather hot.
I do not think a benchmark is necessary for the moment.