### PR TITLE
optimize Money & HighPrecisionMoney

### DIFF
--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -261,7 +261,7 @@ object Money {
   private val centFactorThreeFractionDigit = bdOne / bdTen.pow(3)
   private val centFactorFourFractionDigit = bdOne / bdTen.pow(4)
 
-  def cachedCentFactor(currencyFractionDigits: Int): BigDecimal =
+  private[util] def cachedCentFactor(currencyFractionDigits: Int): BigDecimal =
     currencyFractionDigits match {
       case 0 => centFactorZeroFractionDigit
       case 1 => centFactorOneFractionDigit

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -89,7 +89,7 @@ case class Money private (amount: BigDecimal, currency: Currency) extends BaseMo
     "The scale of the given amount does not match the scale of the provided currency." +
     " - " + amount.scale + " <-> " + currency.getDefaultFractionDigits)
 
-  private val centFactor: Double = Money.cachedCentFactor(currency.getDefaultFractionDigits).doubleValue
+  private val centFactor: Double = 1 / pow(10, currency.getDefaultFractionDigits)
 
   lazy val centAmount: Long = (amount / centFactor).toLong
 


### PR DESCRIPTION
This PR optimizes `Money` & `HighPrecisionMoney`.

- `centFactors` are cached everywhere up to 4 digits
- `Money.zero` is cached for the 4 main currencies

I have added a lot of return types for public usages to make things more explicit but it adds noise to the diff, sorry.