### PR TITLE
FromJson[Collections] even more imperative style for a couple percents improvement

### DIFF
--- a/benchmarks/src/main/scala/json/FromJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromJsonBenchmark.scala
@@ -15,17 +15,17 @@ class FromJsonBenchmark {
 
 *** scala 2.12 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
-FromJsonBenchmark.listReader                  thrpt   10   65,643 ± 1,436  ops/s
-FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   51,019 ± 0,840  ops/s
-FromJsonBenchmark.seqReader                   thrpt   10   68,488 ± 1,299  ops/s
-FromJsonBenchmark.vectorReader                thrpt   10   70,445 ± 0,850  ops/s
+FromJsonBenchmark.listReader                  thrpt   10   64,787 ± 1,081  ops/s
+FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   51,613 ± 0,338  ops/s
+FromJsonBenchmark.seqReader                   thrpt   10   69,606 ± 1,261  ops/s
+FromJsonBenchmark.vectorReader                thrpt   10   75,112 ± 1,022  ops/s
 
 *** scala 2.13 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
-FromJsonBenchmark.listReader                  thrpt   10   63,963 ± 1,789  ops/s
-FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   54,781 ± 0,496  ops/s
-FromJsonBenchmark.seqReader                   thrpt   10   69,365 ± 1,275  ops/s
-FromJsonBenchmark.vectorReader                thrpt   10   70,401 ± 1,839  ops/s
+FromJsonBenchmark.listReader                  thrpt   10   72,133 ± 2,275  ops/s
+FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   52,469 ± 0,428  ops/s
+FromJsonBenchmark.seqReader                   thrpt   10   70,277 ± 1,062  ops/s
+FromJsonBenchmark.vectorReader                thrpt   10   72,930 ± 1,381  ops/s
    */
 
   @Benchmark

--- a/benchmarks/src/main/scala/json/ParseJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/ParseJsonBenchmark.scala
@@ -16,11 +16,11 @@ class ParseJsonBenchmark {
 
 *** scala 2.12 ***
 Benchmark                                     Mode  Cnt   Score   Error  Units
-ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   87,591 ± 0,320  ops/s
+ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   91,432 ± 0,259  ops/s
 
 *** scala 2.13 ***
 Benchmark                                     Mode  Cnt   Score   Error  Units
-ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   87,495 ± 0,388  ops/s
+ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   91,497 ± 0,312  ops/s
    */
 
   @Benchmark


### PR DESCRIPTION
I did several runs and in average this implementation is very often significantly faster (more than 3%) .

They should have the same semantic:
- gather all errors
- stop gathering success once we have one error