### PR TITLE
show impact of parsing DateTime for a more realistic benchmark

### DIFF
--- a/benchmarks/src/main/scala/json/FromJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromJsonBenchmark.scala
@@ -16,14 +16,14 @@ class FromJsonBenchmark {
 *** scala 2.12 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
 FromJsonBenchmark.listReader                  thrpt   10   69,925 ± 0,776  ops/s
-FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   54,620 ± 0,513  ops/s
+FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   19,010 ± 0,186  ops/s
 FromJsonBenchmark.seqReader                   thrpt   10   72,595 ± 0,737  ops/s
 FromJsonBenchmark.vectorReader                thrpt   10   71,278 ± 0,896  ops/s
 
 *** scala 2.13 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
 FromJsonBenchmark.listReader                  thrpt   10   70,661 ±  1,623  ops/s
-FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   55,864 ±  0,649  ops/s
+FromJsonBenchmark.parseFromStringToCaseClass  thrpt   10   19,288 ±  0,118  ops/s
 FromJsonBenchmark.seqReader                   thrpt   10   72,897 ±  1,317  ops/s
 FromJsonBenchmark.vectorReader                thrpt   10   72,016 ±  0,552  ops/s
    */

--- a/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
@@ -15,11 +15,11 @@ jmh:run
 
 *** scala 2.12 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
-FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  296,535 ± 7,499  ops/s
+FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  27,927 ± 0,180  ops/s
 
 *** scala 2.13 ***
 Benchmark                                      Mode  Cnt   Score   Error  Units
-FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  324,384 ± 10,068  ops/s
+FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  28,450 ± 0,218  ops/s
  */
 
   @Benchmark

--- a/benchmarks/src/main/scala/json/ParseJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/ParseJsonBenchmark.scala
@@ -16,11 +16,11 @@ class ParseJsonBenchmark {
 
 *** scala 2.12 ***
 Benchmark                                     Mode  Cnt   Score   Error  Units
-ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   92,637 ± 1,094  ops/s
+ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   71,394 ± 0,459  ops/s
 
 *** scala 2.13 ***
 Benchmark                                     Mode  Cnt   Score   Error  Units
-ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   92,600 ±  0,504  ops/s
+ParseJsonBenchmark.parseFromStringToJValue    thrpt   10   72,156 ± 0,403  ops/s
    */
 
   @Benchmark

--- a/benchmarks/src/main/scala/json/ToJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/ToJsonBenchmark.scala
@@ -22,7 +22,7 @@ class ToJsonBenchmark {
 *** scala 2.12 ***
 Benchmark                                    Mode  Cnt   Score   Error  Units
 ToJsonBenchmark.listWriter                    thrpt   10   70,604 ± 1,277  ops/s
-ToJsonBenchmark.seqWriter                     thrpt   10   59,555 ± 1,253  ops/s
+ToJsonBenchmark.seqWriter                     thrpt   10   28,650 ± 0,311  ops/s
 ToJsonBenchmark.serializeCaseClassToString    thrpt   10   51,404 ± 0,748  ops/s
 ToJsonBenchmark.vectorWriter                  thrpt   10   61,722 ± 1,770  ops/s
 
@@ -30,7 +30,7 @@ ToJsonBenchmark.vectorWriter                  thrpt   10   61,722 ± 1,770  ops/
 Benchmark                                    Mode  Cnt   Score   Error  Units
 ToJsonBenchmark.listWriter                    thrpt   10   73,688 ±  1,381  ops/s
 ToJsonBenchmark.seqWriter                     thrpt   10   70,049 ±  1,697  ops/s
-ToJsonBenchmark.serializeCaseClassToString    thrpt   10   56,701 ±  1,206  ops/s
+ToJsonBenchmark.serializeCaseClassToString    thrpt   10   29,107 ± 0,417  ops/s
 ToJsonBenchmark.vectorWriter                  thrpt   10   70,300 ±  1,833  ops/s
    */
 

--- a/benchmarks/src/main/scala/json/ToMongoValueBenchmark.scala
+++ b/benchmarks/src/main/scala/json/ToMongoValueBenchmark.scala
@@ -15,11 +15,11 @@ jmh:run
 
 *** scala 2.12 ***
 Benchmark                                     Mode  Cnt   Score   Error  Units
-ToMongoValueBenchmark.caseClassToMongoValue   thrpt   10  230,961 ± 4,864  ops/s
+ToMongoValueBenchmark.caseClassToMongoValue   thrpt   10  79,065 ± 1,075  ops/s
 
 *** scala 2.13 ***
 Benchmark                                     Mode  Cnt   Score   Error  Units
-ToMongoValueBenchmark.caseClassToMongoValue   thrpt   10  282,412 ±  5,712  ops/s
+ToMongoValueBenchmark.caseClassToMongoValue   thrpt   10  80,242 ± 1,033  ops/s
 */
 
 


### PR DESCRIPTION
This PR show impact of parsing `DateTime` for a more realistic benchmark.

The slowdown is massive for `Json` and `MongoFormat`.

I'll research if we can improve here as it would yield great benefits for our use case.