### PR TITLE
add sphere-mongo-derivation-magnolia

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val `sphere-libs` = project.in(file("."))
     publishArtifact := false,
     publish := {})
   .disablePlugins(BintrayPlugin)
-  .aggregate(`sphere-util`, `sphere-json`, `sphere-mongo`)
+  .aggregate(`sphere-util`, `sphere-json`, `sphere-mongo`, `sphere-mongo-derivation-magnolia`)
 
 lazy val `sphere-util` = project.in(file("./util"))
   .settings(standardSettings: _*)
@@ -57,6 +57,10 @@ lazy val `sphere-mongo-core` = project.in(file("./mongo/mongo-core"))
 lazy val `sphere-mongo-derivation` = project.in(file("./mongo/mongo-derivation"))
   .settings(standardSettings: _*)
   .settings(Fmpp.settings: _*)
+  .dependsOn(`sphere-mongo-core`)
+
+lazy val `sphere-mongo-derivation-magnolia` = project.in(file("./mongo/mongo-derivation-magnolia"))
+  .settings(standardSettings: _*)
   .dependsOn(`sphere-mongo-core`)
 
 lazy val `sphere-mongo` = project.in(file("./mongo"))

--- a/mongo/mongo-derivation-magnolia/dependencies.sbt
+++ b/mongo/mongo-derivation-magnolia/dependencies.sbt
@@ -1,0 +1,3 @@
+libraryDependencies ++= Seq(
+  "com.propensive" %% "magnolia" % "0.16.0"
+)

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoEmbedded.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoEmbedded.scala
@@ -1,0 +1,5 @@
+package io.sphere.mongo.generic
+
+import scala.annotation.StaticAnnotation
+
+class MongoEmbedded extends StaticAnnotation

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoIgnore.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoIgnore.scala
@@ -1,0 +1,5 @@
+package io.sphere.mongo.generic
+
+import scala.annotation.StaticAnnotation
+
+class MongoIgnore extends StaticAnnotation

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoKey.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoKey.scala
@@ -1,0 +1,5 @@
+package io.sphere.mongo.generic
+
+import scala.annotation.StaticAnnotation
+
+case class MongoKey(value: String) extends StaticAnnotation

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoTypeHint.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoTypeHint.scala
@@ -1,0 +1,5 @@
+package io.sphere.mongo.generic
+
+import scala.annotation.StaticAnnotation
+
+case class MongoTypeHint(value: String) extends StaticAnnotation

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoTypeHintField.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/MongoTypeHintField.scala
@@ -1,0 +1,9 @@
+package io.sphere.mongo.generic
+
+import scala.annotation.StaticAnnotation
+
+case class MongoTypeHintField(value: String = MongoTypeHintField.defaultValue) extends StaticAnnotation
+
+object MongoTypeHintField {
+  final val defaultValue: String = "type"
+}

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/package.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/package.scala
@@ -1,0 +1,266 @@
+package io.sphere.mongo
+
+import com.mongodb.{BasicDBObject, DBObject}
+import io.sphere.mongo.format.{MongoFormat, MongoNothing, toMongo}
+import io.sphere.util.{Logging, Memoizer}
+import magnolia._
+import org.bson.BSONObject
+
+import scala.language.experimental.macros
+
+package object generic extends Logging {
+
+  /**
+  * Creates a MongoFormat instance for an Enumeration type that encodes the `toString`
+  * representations of the enumeration values.
+  */
+  def mongoEnum(e: Enumeration): MongoFormat[e.Value] = new MongoFormat[e.Value] {
+    def toMongoValue(a: e.Value): Any = a.toString
+    def fromMongoValue(any: Any): e.Value = e.withName(any.asInstanceOf[String])
+  }
+
+  type Typeclass[T] = MongoFormat[T]
+
+  def deriveMongoFormat[T]: MongoFormat[T] = macro Magnolia.gen[T]
+  def mongoProduct[T]: MongoFormat[T] = macro Magnolia.gen[T]
+
+  def combine[T <: Product](caseClass: CaseClass[MongoFormat, T]): MongoFormat[T] = new MongoFormat[T] {
+    private val mongoClass = getMongoClassMeta(caseClass)
+    private val _fields = mongoClass.fields
+
+    override def toMongoValue(r: T): Any = {
+      val dbo = new BasicDBObject
+      mongoClass.typeHint
+        .foreach(th => dbo.put(th.field, th.value))
+
+      var i = 0
+      caseClass.parameters.foreach { p =>
+        writeField(dbo, _fields(i), p.dereference(r))(p.typeclass)
+        i += 1
+      }
+      dbo
+    }
+
+    override def fromMongoValue(any: Any): T = any match {
+      case dbo: DBObject =>
+        var i = -1
+        val fieldValues: Seq[Any] = caseClass.parameters.map { p =>
+          i += 1
+          readField(_fields(i), dbo)(p.typeclass)
+        }
+        caseClass.rawConstruct(fieldValues)
+      case _ => sys.error("Deserialization failed. DBObject expected.")
+    }
+
+    override val fields: Set[String] = calculateFields()
+    private def calculateFields(): Set[String] = {
+      val builder = Set.newBuilder[String]
+      var i = 0
+      caseClass.parameters.foreach { p =>
+        val f = _fields(i)
+        if (!f.ignored) {
+          if (f.embedded)
+            builder ++= p.typeclass.fields
+          else
+            builder += f.name
+        }
+        i += 1
+      }
+      builder.result()
+    }
+  }
+
+  def dispatch[T](sealedTrait: SealedTrait[MongoFormat, T]): MongoFormat[T] = new MongoFormat[T] {
+
+    val allSelectors = sealedTrait.subtypes.map { subType =>
+      typeSelector(subType)
+    }
+    val readMapBuilder = Map.newBuilder[String, TypeSelector[_]]
+    val writeMapBuilder = Map.newBuilder[TypeName, TypeSelector[_]]
+    allSelectors.foreach { s =>
+      readMapBuilder += (s.typeValue -> s)
+      writeMapBuilder += (s.subType.typeName -> s)
+    }
+    val readMap = readMapBuilder.result
+    val writeMap = writeMapBuilder.result
+
+    private val typeField = sealedTrait.annotations.collectFirst {
+      case a: MongoTypeHintField => a.value
+    }.getOrElse(defaultTypeFieldName)
+
+    override def toMongoValue(t: T): Any = {
+      sealedTrait.dispatch(t) { subtype =>
+        writeMap.get(subtype.typeName) match {
+          case None => new BasicDBObject(defaultTypeFieldName, defaultTypeValue(subtype.typeName))
+          case Some(w) => subtype.typeclass.toMongoValue(subtype.cast(t)) match {
+            case dbo: BSONObject => findTypeValue(dbo, w.typeField) match {
+              case Some(_) => dbo
+              case None =>
+                dbo.put(w.typeField, w.typeValue)
+                dbo
+            }
+            case _ => throw new Exception("Excepted 'BSONObject'")
+          }
+        }
+      }
+    }
+
+    override def fromMongoValue(any: Any): T = {
+      any match {
+        case dbo: BSONObject =>
+          findTypeValue(dbo, typeField) match {
+            case Some(t) => readMap.get(t) match {
+              case Some(r) => r.subType.typeclass.fromMongoValue(dbo).asInstanceOf[T]
+              case None => sys.error("Invalid type value '" + t + "' in DBObject '%s'.".format(dbo))
+            }
+            case None => sys.error("Missing type field '" + typeField + "' in DBObject '%s'.".format(dbo))
+          }
+        case _ => sys.error("DBObject expected.")
+      }
+    }
+  }
+
+  private val defaultTypeFieldName: String = MongoTypeHintField.defaultValue
+
+  private case class MongoClassMeta(typeHint: Option[MongoClassMeta.TypeHint], fields: IndexedSeq[MongoFieldMeta])
+  private object MongoClassMeta {
+    case class TypeHint(field: String, value: String)
+  }
+  private case class MongoFieldMeta(
+    name: String,
+    default: Option[Any] = None,
+    embedded: Boolean = false,
+    ignored: Boolean = false
+  )
+
+  private val getMongoClassMeta = new Memoizer[CaseClass[MongoFormat, _], MongoClassMeta](caseClass => {
+    def hintVal(h: generic.MongoTypeHint): String =
+      if (h.value.isEmpty) defaultTypeValue(caseClass.typeName)
+      else h.value
+
+    log.trace("Initializing Mongo metadata for %s".format(caseClass.typeName.full))
+
+    val annotations = caseClass.annotations
+
+    val typeHintFieldAnnot: Option[MongoTypeHintField] = annotations.collectFirst {
+      case h: MongoTypeHintField => h
+    }
+    val typeHintAnnot: Option[generic.MongoTypeHint] = annotations.collectFirst {
+      case h: generic.MongoTypeHint => h
+    }
+    val typeField = typeHintFieldAnnot.map(_.value)
+    val typeValue = typeHintAnnot.map(hintVal)
+
+    MongoClassMeta(
+      typeHint = (typeField, typeValue) match {
+        case (Some(field), Some(hint)) => Some(MongoClassMeta.TypeHint(field, hint))
+        case (None       , Some(hint)) => Some(MongoClassMeta.TypeHint(defaultTypeFieldName, hint))
+        case (Some(field), None)       => Some(MongoClassMeta.TypeHint(field, defaultTypeValue(caseClass.typeName)))
+        case (None       , None)       => None
+      },
+      fields = getMongoFieldMeta(caseClass)
+    )
+  })
+
+  private val getMongoClassMetaFromSubType = new Memoizer[Subtype[MongoFormat, _], MongoClassMeta](subType => {
+    def hintVal(h: generic.MongoTypeHint): String =
+      if (h.value.isEmpty) defaultTypeValue(subType.typeName)
+      else h.value
+
+    log.trace("Initializing Mongo metadata for %s".format(subType.typeName.full))
+
+    val annotations = subType.annotations
+
+    val typeHintFieldAnnot: Option[MongoTypeHintField] = annotations.collectFirst {
+      case h: MongoTypeHintField => h
+    }
+    val typeHintAnnot: Option[generic.MongoTypeHint] = annotations.collectFirst {
+      case h: generic.MongoTypeHint => h
+    }
+    val typeField = typeHintFieldAnnot.map(_.value)
+    val typeValue = typeHintAnnot.map(hintVal)
+
+    MongoClassMeta(
+      typeHint = (typeField, typeValue) match {
+        case (Some(field), Some(hint)) => Some(MongoClassMeta.TypeHint(field, hint))
+        case (None       , Some(hint)) => Some(MongoClassMeta.TypeHint(defaultTypeFieldName, hint))
+        case (Some(field), None)       => Some(MongoClassMeta.TypeHint(field, defaultTypeValue(subType.typeName)))
+        case (None       , None)       => None
+      },
+      fields = IndexedSeq[MongoFieldMeta]()
+    )
+  })
+
+  private def getMongoFieldMeta(caseClass: CaseClass[MongoFormat, _]): IndexedSeq[MongoFieldMeta] = {
+    caseClass.parameters.map { p =>
+      val annotations = p.annotations
+      val name = annotations.collectFirst {
+        case h: MongoKey => h
+      }.fold(p.label)(_.value)
+      val embedded = annotations.exists {
+        case _: MongoEmbedded => true
+        case _ => false
+      }
+      val ignored = annotations.exists {
+        case _: MongoIgnore => true
+        case _ => false
+      }
+      if (ignored && p.default.isEmpty) {
+        throw new Exception("Ignored Mongo field '%s' must have a default value.".format(p.label))
+      }
+      MongoFieldMeta(name, p.default, embedded, ignored)
+    }.toIndexedSeq
+  }
+
+  private def writeField[A: MongoFormat](dbo: DBObject, field: MongoFieldMeta, e: A): Unit = {
+    if (!field.ignored) {
+      if (field.embedded)
+        toMongo(e) match {
+          case dbo2: DBObject => dbo.putAll(dbo2)
+          case MongoNothing => ()
+          case x => dbo.put(field.name, x)
+        }
+      else
+        toMongo(e) match {
+          case MongoNothing => ()
+          case x => dbo.put(field.name, x)
+        }
+    }
+  }
+
+  private def readField[A: MongoFormat](f: MongoFieldMeta, dbo: DBObject): A = {
+    val mf = MongoFormat[A]
+    def default = f.default.asInstanceOf[Option[A]].orElse(mf.default)
+    if (f.ignored)
+      default.getOrElse {
+        throw new Exception("Missing default for ignored field '%s'.".format(f.name))
+      }
+    else if (f.embedded) mf.fromMongoValue(dbo)
+    else {
+      val value = dbo.get(f.name)
+      if (value != null) mf.fromMongoValue(value)
+      else {
+        default.getOrElse {
+          throw new Exception("Missing required field '%s' on deserialization.".format(f.name))
+        }
+      }
+    }
+  }
+
+  private def findTypeValue(dbo: BSONObject, typeField: String): Option[String] =
+    Option(dbo.get(typeField)).map(_.toString)
+
+  private case class TypeSelector[A](val typeField: String, val typeValue: String, subType: Subtype[MongoFormat, A])
+
+  private def typeSelector[A](subType: Subtype[MongoFormat, A]): TypeSelector[A] = {
+    val (typeField, typeValue) = getMongoClassMetaFromSubType(subType).typeHint match {
+      case Some(hint) => (hint.field, hint.value)
+      case None => (defaultTypeFieldName, defaultTypeValue(subType.typeName))
+    }
+    new TypeSelector[A](typeField, typeValue, subType)
+  }
+
+  private def defaultTypeValue(typeName: TypeName): String =
+    typeName.short.replace("$", "")
+
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/MongoUtils.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/MongoUtils.scala
@@ -1,0 +1,9 @@
+package io.sphere.mongo
+import com.mongodb.BasicDBObject
+
+object MongoUtils {
+
+  def dbObj(pairs: (String, Any)*) =
+    pairs.foldLeft(new BasicDBObject){case (obj, (key, value)) => obj.append(key, value)}
+
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/SerializationTest.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/SerializationTest.scala
@@ -1,0 +1,61 @@
+package io.sphere.mongo
+
+import com.mongodb.{BasicDBObject, DBObject}
+import org.scalatest.matchers.must.Matchers
+import io.sphere.mongo.format.MongoFormat
+import io.sphere.mongo.format.DefaultMongoFormats._
+import org.scalatest.wordspec.AnyWordSpec
+
+object SerializationTest {
+  case class Something(a: Option[Int], b: Int = 2)
+
+  object Color extends Enumeration {
+    val Blue, Red, Yellow = Value
+  }
+}
+
+class SerializationTest extends AnyWordSpec with Matchers {
+  import SerializationTest._
+
+  "mongoProduct" must {
+    "deserialize mongo object" in {
+      val dbo = new BasicDBObject()
+      dbo.put("a", Integer.valueOf(3))
+      dbo.put("b", Integer.valueOf(4))
+
+      val mongoFormat: MongoFormat[Something] = io.sphere.mongo.generic.deriveMongoFormat
+      val something = mongoFormat.fromMongoValue(dbo)
+      something must be (Something(Some(3), 4))
+    }
+
+    "generate a format that serializes optional fields with value None as BSON objects without that field" in {
+      val testFormat: MongoFormat[Something] = io.sphere.mongo.generic.mongoProduct[Something]
+      val serializedObject = testFormat.toMongoValue(Something(None, 1)).asInstanceOf[DBObject]
+      serializedObject.keySet().contains("b") must be(true)
+      serializedObject.keySet().contains("a") must be(false)
+    }
+
+    "generate a format that use default values" in {
+      val dbo = new BasicDBObject()
+      dbo.put("a", Integer.valueOf(3))
+
+      val mongoFormat: MongoFormat[Something] = io.sphere.mongo.generic.deriveMongoFormat
+      val something = mongoFormat.fromMongoValue(dbo)
+      something must be (Something(Some(3), 2))
+    }
+  }
+
+  "mongoEnum" must {
+    "serialize and deserialize enums" in {
+      val mongo: MongoFormat[Color.Value] = generic.mongoEnum(Color)
+
+      // mongo java driver knows how to encode/decode Strings
+      val serializedObject = mongo.toMongoValue(Color.Red).asInstanceOf[String]
+      serializedObject must be ("Red")
+
+      val enumValue = mongo.fromMongoValue(serializedObject)
+      enumValue must be (Color.Red)
+    }
+  }
+
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/format/OptionMongoFormatSpec.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/format/OptionMongoFormatSpec.scala
@@ -1,0 +1,99 @@
+package io.sphere.mongo.format
+
+import io.sphere.mongo.generic._
+import org.scalatest.OptionValues
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.sphere.mongo.MongoUtils._
+import DefaultMongoFormats._
+
+object OptionMongoFormatSpec {
+
+  case class SimpleClass(value1: String, value2: Int)
+
+  object SimpleClass {
+    implicit val mongo: MongoFormat[SimpleClass] = mongoProduct
+  }
+
+  case class ComplexClass(
+    name: String,
+    simpleClass: Option[SimpleClass])
+
+  object ComplexClass {
+    implicit val mongo: MongoFormat[ComplexClass] = mongoProduct
+  }
+
+}
+
+
+class OptionMongoFormatSpec extends AnyWordSpec with Matchers with OptionValues {
+  import OptionMongoFormatSpec._
+
+  "MongoFormat[Option[_]]" should {
+    "handle presence of all fields" in {
+      val dbo = dbObj(
+        "value1" -> "a",
+        "value2" -> 45
+      )
+      val result = MongoFormat[Option[SimpleClass]].fromMongoValue(dbo)
+      result.value.value1 mustEqual "a"
+      result.value.value2 mustEqual 45
+    }
+
+    "handle presence of all fields mixed with ignored fields" in {
+      val dbo = dbObj(
+        "value1" -> "a",
+        "value2" -> 45,
+        "value3" -> "b"
+      )
+      val result = MongoFormat[Option[SimpleClass]].fromMongoValue(dbo)
+      result.value.value1 mustEqual "a"
+      result.value.value2 mustEqual 45
+    }
+
+    "handle presence of not all the fields" in {
+      val dbo = dbObj("value1" -> "a")
+      an[Exception] mustBe thrownBy (MongoFormat[Option[SimpleClass]].fromMongoValue(dbo))
+    }
+
+    "handle absence of all fields" in {
+      val dbo = dbObj()
+      val result = MongoFormat[Option[SimpleClass]].fromMongoValue(dbo)
+      result mustEqual None
+    }
+
+    "handle absence of all fields mixed with ignored fields" in {
+      val dbo = dbObj("value3" -> "a")
+      val result = MongoFormat[Option[SimpleClass]].fromMongoValue(dbo)
+      result mustEqual None
+    }
+
+    "consider all fields if the data type does not impose any restriction" in {
+      val dbo = dbObj(
+        "key1" -> "value1",
+        "key2" -> "value2"
+      )
+      val expected = Map("key1" -> "value1", "key2" -> "value2")
+      val result = MongoFormat[Map[String, String]].fromMongoValue(dbo)
+      result mustEqual expected
+
+      val maybeResult = MongoFormat[Option[Map[String, String]]].fromMongoValue(dbo)
+      maybeResult.value mustEqual expected
+    }
+
+    "parse optional element" in {
+      val dbo = dbObj(
+        "name" -> "ze name",
+        "simpleClass" -> dbObj(
+          "value1" -> "value1",
+          "value2" -> 42
+        )
+      )
+      val result = MongoFormat[ComplexClass].fromMongoValue(dbo)
+      result.simpleClass.value.value1 mustEqual "value1"
+      result.simpleClass.value.value2 mustEqual 42
+
+      MongoFormat[ComplexClass].toMongoValue(result) mustEqual dbo
+    }
+  }
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/DefaultValuesSpec.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/DefaultValuesSpec.scala
@@ -1,0 +1,34 @@
+package io.sphere.mongo.generic
+
+import io.sphere.mongo.MongoUtils._
+import io.sphere.mongo.format.DefaultMongoFormats._
+import io.sphere.mongo.format.MongoFormat
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DefaultValuesSpec extends AnyWordSpec with Matchers {
+  import DefaultValuesSpec._
+
+  "deriving MongoFormat" must {
+    "handle default values" in {
+      val dbo = dbObj()
+      val test = MongoFormat[Test].fromMongoValue(dbo)
+      test.value1 must be ("hello")
+      test.value2 must be (None)
+      test.value3 must be (None)
+      test.value4 must be (Some("hi"))
+    }
+  }
+}
+
+object DefaultValuesSpec {
+  case class Test(
+    value1: String = "hello",
+    value2: Option[String],
+    value3: Option[String] = None,
+    value4: Option[String] = Some("hi")
+  )
+  object Test {
+    implicit val mongo: MongoFormat[Test] = mongoProduct
+  }
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/DeriveMongoformatSpec.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/DeriveMongoformatSpec.scala
@@ -1,0 +1,124 @@
+package io.sphere.mongo.generic
+
+import io.sphere.mongo.format.MongoFormat
+import io.sphere.mongo.format._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.sphere.mongo.format.DefaultMongoFormats._
+import io.sphere.mongo.MongoUtils._
+
+class DeriveMongoformatSpec extends AnyWordSpec with Matchers {
+  import DeriveMongoformatSpec._
+
+  "deriving MongoFormat" must {
+    "read normal singleton values" in {
+      val user = fromMongo[UserWithPicture](
+        dbObj(
+          "userId" -> "foo-123",
+          "pictureSize" -> dbObj(
+            "type" -> "Medium"),
+          "pictureUrl" -> "http://example.com"))
+
+      user must be (UserWithPicture("foo-123", Medium, "http://example.com"))
+    }
+
+    "read custom singleton values" in {
+      val user = fromMongo[UserWithPicture](
+        dbObj(
+          "userId" -> "foo-123",
+          "pictureSize" -> dbObj(
+            "type" -> "bar",
+            "width" -> 23,
+            "height" -> 30),
+          "pictureUrl" -> "http://example.com"))
+
+      user must be (UserWithPicture("foo-123", Custom(23, 30), "http://example.com"))
+    }
+
+    "fail to read if singleton value is unknown" in {
+      a [Exception] must be thrownBy fromMongo[UserWithPicture](
+        dbObj(
+          "userId" -> "foo-123",
+          "pictureSize" -> dbObj(
+            "type" -> "Unknown"),
+          "pictureUrl" -> "http://example.com"))
+    }
+
+    "write normal singleton values" in {
+      val dbo = toMongo[UserWithPicture](UserWithPicture("foo-123", Medium, "http://example.com"))
+      dbo must be (dbObj(
+          "userId" -> "foo-123",
+          "pictureSize" -> dbObj(
+            "type" -> "Medium"),
+          "pictureUrl" -> "http://example.com"))
+    }
+
+    "write custom singleton values" in {
+      val dbo = toMongo[UserWithPicture](UserWithPicture("foo-123", Custom(23, 30), "http://example.com"))
+      dbo must be (dbObj(
+          "userId" -> "foo-123",
+          "pictureSize" -> dbObj(
+            "type" -> "bar",
+            "width" -> 23,
+            "height" -> 30),
+          "pictureUrl" -> "http://example.com"))
+    }
+
+    "write and consequently read, which must produce the original value" in {
+      val originalUser = UserWithPicture("foo-123", Medium, "http://exmple.com")
+      val newUser = fromMongo[UserWithPicture](toMongo[UserWithPicture](originalUser))
+
+      newUser must be (originalUser)
+    }
+
+    "read and write sealed trait with only one subtype" in {
+      val dbo = dbObj(
+          "userId" -> "foo-123",
+          "pictureSize" -> dbObj(
+            "type" -> "Medium"),
+          "pictureUrl" -> "http://example.com",
+          "access" -> dbObj(
+            "type" -> "Authorized",
+            "project" -> "internal"))
+      val user = fromMongo[UserWithPicture](dbo)
+
+      user must be (UserWithPicture("foo-123", Medium, "http://example.com", Some(Access.Authorized("internal"))))
+      val newDbo = toMongo[UserWithPicture](user)
+      newDbo must be (dbo)
+
+      val newUser = fromMongo[UserWithPicture](newDbo)
+      newUser must be (user)
+    }
+  }
+}
+
+object DeriveMongoformatSpec {
+  sealed trait PictureSize
+  case object Small extends PictureSize
+  case object Medium extends PictureSize
+  case object Big extends PictureSize
+  @MongoTypeHint(value = "bar")
+  case class Custom(width: Int, height: Int) extends PictureSize
+
+  object PictureSize {
+    implicit val mongo: MongoFormat[PictureSize] = deriveMongoFormat[PictureSize]
+  }
+
+  sealed trait Access
+  object Access {
+    // only one sub-type
+    case class Authorized(project: String) extends Access
+
+    implicit val mongo: MongoFormat[Access] = deriveMongoFormat
+  }
+
+  case class UserWithPicture(
+    userId: String,
+    pictureSize: PictureSize,
+    pictureUrl: String,
+    access: Option[Access] = None)
+
+  object UserWithPicture {
+    implicit val mongo: MongoFormat[UserWithPicture] = mongoProduct
+  }
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/MongoEmbeddedSpec.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/MongoEmbeddedSpec.scala
@@ -1,0 +1,151 @@
+package io.sphere.mongo.generic
+
+import io.sphere.mongo.format.MongoFormat
+import org.scalatest.OptionValues
+import org.scalatest.matchers.must.Matchers
+import io.sphere.mongo.format.DefaultMongoFormats._
+import io.sphere.mongo.MongoUtils._
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
+
+object MongoEmbeddedSpec {
+  case class Embedded(
+     value1: String,
+     @MongoKey("_value2") value2: Int)
+
+  object Embedded {
+    implicit val mongo: MongoFormat[Embedded] = mongoProduct
+  }
+
+  case class Test1(
+    name: String,
+    @MongoEmbedded embedded: Embedded)
+
+  object Test1 {
+    implicit val mongo: MongoFormat[Test1] = mongoProduct
+  }
+
+  case class Test2(
+    name: String,
+    @MongoEmbedded embedded: Option[Embedded] = None)
+
+  object Test2 {
+    implicit val mongo: MongoFormat[Test2] = mongoProduct
+  }
+
+  case class Test3(
+    @MongoIgnore name: String = "default",
+    @MongoEmbedded embedded: Option[Embedded] = None)
+
+  object Test3 {
+    implicit val mongo: MongoFormat[Test3] = mongoProduct
+  }
+
+  case class SubTest4(@MongoEmbedded embedded: Embedded)
+  object SubTest4 {
+    implicit val mongo: MongoFormat[SubTest4] = mongoProduct
+  }
+
+  case class Test4(subField: Option[SubTest4] = None)
+  object Test4 {
+    implicit val mongo: MongoFormat[Test4] = mongoProduct
+  }
+}
+
+class MongoEmbeddedSpec extends AnyWordSpec with Matchers with OptionValues {
+  import MongoEmbeddedSpec._
+
+  "MongoEmbedded" should {
+    "flatten the db object in one object" in {
+      val dbo = dbObj(
+        "name" -> "ze name",
+        "value1" -> "ze value1",
+        "_value2" -> 45
+      )
+      val test1 = MongoFormat[Test1].fromMongoValue(dbo)
+      test1.name mustEqual "ze name"
+      test1.embedded.value1 mustEqual "ze value1"
+      test1.embedded.value2 mustEqual 45
+
+      val result = MongoFormat[Test1].toMongoValue(test1)
+      result mustEqual dbo
+    }
+
+    "validate that the db object contains all needed fields" in {
+      val dbo = dbObj(
+        "name" -> "ze name",
+        "value1" -> "ze value1"
+      )
+      Try(MongoFormat[Test1].fromMongoValue(dbo)).isFailure must be (true)
+    }
+
+    "support optional embedded attribute" in {
+      val dbo = dbObj(
+        "name" -> "ze name",
+        "value1" -> "ze value1",
+        "_value2" -> 45
+      )
+      val test2 = MongoFormat[Test2].fromMongoValue(dbo)
+      test2.name mustEqual "ze name"
+      test2.embedded.value.value1 mustEqual "ze value1"
+      test2.embedded.value.value2 mustEqual 45
+
+      val result = MongoFormat[Test2].toMongoValue(test2)
+      result mustEqual dbo
+    }
+
+    "ignore unknown fields" in {
+      val dbo = dbObj(
+        "name" -> "ze name",
+        "value1" -> "ze value1",
+        "_value2" -> 45,
+        "value4" -> true
+      )
+      val test2 = MongoFormat[Test2].fromMongoValue(dbo)
+      test2.name mustEqual "ze name"
+      test2.embedded.value.value1 mustEqual "ze value1"
+      test2.embedded.value.value2 mustEqual 45
+    }
+
+    "ignore ignored fields" in {
+      val dbo = dbObj(
+        "value1" -> "ze value1",
+        "_value2" -> 45
+      )
+      val test3 = MongoFormat[Test3].fromMongoValue(dbo)
+      test3.name mustEqual "default"
+      test3.embedded.value.value1 mustEqual "ze value1"
+      test3.embedded.value.value2 mustEqual 45
+    }
+
+    "check for sub-fields" in {
+      val dbo = dbObj(
+        "subField" -> dbObj(
+          "value1" -> "ze value1",
+          "_value2" -> 45
+        )
+      )
+      val test4 = MongoFormat[Test4].fromMongoValue(dbo)
+      test4.subField.value.embedded.value1 mustEqual "ze value1"
+      test4.subField.value.embedded.value2 mustEqual 45
+    }
+
+    "support the absence of optional embedded attribute" in {
+      val dbo = dbObj(
+        "name" -> "ze name"
+      )
+      val test2 = MongoFormat[Test2].fromMongoValue(dbo)
+      test2.name mustEqual "ze name"
+      test2.embedded mustEqual None
+    }
+
+    "validate the absence of some embedded attributes" in {
+      val dbo = dbObj(
+        "name" -> "ze name",
+        "value1" -> "ze value1"
+      )
+      Try(MongoFormat[Test2].fromMongoValue(dbo)).isFailure must be (true)
+    }
+  }
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/MongoKeySpec.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/MongoKeySpec.scala
@@ -1,0 +1,51 @@
+package io.sphere.mongo.generic
+
+import io.sphere.mongo.format.DefaultMongoFormats._
+import io.sphere.mongo.format.MongoFormat
+import org.bson.BSONObject
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.JavaConverters._
+
+class MongoKeySpec extends AnyWordSpec with Matchers {
+  import MongoKeySpec._
+
+  "deriving MongoFormat" must {
+    "rename fields annotated with @MongoKey" in {
+      val test = Test(
+        value1 = "value1",
+        value2 = "value2",
+        subTest = SubTest(
+          value2 = "other_value2"))
+
+      val dbo = MongoFormat[Test].toMongoValue(test)
+      val map = dbo.asInstanceOf[BSONObject].toMap.asScala.toMap[Any, Any]
+      map.get("value1") must equal (Some("value1"))
+      map.get("value2") must equal (None)
+      map.get("new_value_2") must equal (Some("value2"))
+      map.get("new_sub_value_2") must equal (Some("other_value2"))
+
+      val newTest = MongoFormat[Test].fromMongoValue(dbo)
+      newTest must be (test)
+    }
+  }
+}
+
+object MongoKeySpec {
+  case class SubTest(
+    @MongoKey("new_sub_value_2") value2: String
+  )
+  object SubTest {
+    implicit val mongo: MongoFormat[SubTest] = mongoProduct
+  }
+
+  case class Test(
+    value1: String,
+    @MongoKey("new_value_2") value2: String,
+    @MongoEmbedded subTest: SubTest
+  )
+  object Test {
+    implicit val mongo: MongoFormat[Test] = mongoProduct
+  }
+}

--- a/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/MongoTypeHintFieldSpec.scala
+++ b/mongo/mongo-derivation-magnolia/src/test/scala/io/sphere/mongo/generic/MongoTypeHintFieldSpec.scala
@@ -10,19 +10,7 @@ class MongoTypeHintFieldSpec extends AnyWordSpec with Matchers {
   import MongoTypeHintFieldSpec._
 
   "MongoTypeHintField" must {
-    "allow to set another field to distinguish between types (toMongo)" in {
-      val user = UserWithPicture("foo-123", Medium, "http://example.com")
-      val expected = dbObj(
-        "userId" -> "foo-123",
-        "pictureSize" -> dbObj(
-          "pictureType" -> "Medium"),
-        "pictureUrl" -> "http://example.com")
-
-      val dbo = toMongo[UserWithPicture](user)
-      dbo must be (expected)
-    }
-
-    "allow to set another field to distinguish between types (fromMongo)" in {
+    "allow to set another field to distinguish between types" in {
       val initialDbo = dbObj(
         "userId" -> "foo-123",
         "pictureSize" -> dbObj(
@@ -60,6 +48,6 @@ object MongoTypeHintFieldSpec {
     pictureUrl: String)
 
   object UserWithPicture {
-    implicit val mongo: MongoFormat[UserWithPicture] = mongoProduct(apply _)
+    implicit val mongo: MongoFormat[UserWithPicture] = mongoProduct
   }
 }


### PR DESCRIPTION
Step 2 of https://github.com/sphereio/sphere-scala-libs/issues/174

The tests are similar to the ones in sphere-mongo-derivation (almost copy/paste except the `mongoProduct` instead of `mongoProduct(apply _)`.
We have to make sure the keep those tests consistent in the future.