### PR TITLE
Optimise mongo format

### DIFF
--- a/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
@@ -1,6 +1,7 @@
 package json
 
 import io.sphere.mongo.format.fromMongo
+import io.sphere.mongo.format.DefaultMongoFormats._
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Fork, Measurement, Mode, Scope, State, Warmup}
 
 @State(Scope.Benchmark)
@@ -13,19 +14,36 @@ class FromMongoBenchmark {
   /* on local mac
 jmh:run
 
-*** scala 2.12 ***
-Benchmark                                      Mode  Cnt   Score   Error  Units
-FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  27,927 ± 0,180  ops/s
-
 *** scala 2.13 ***
-Benchmark                                      Mode  Cnt   Score   Error  Units
-FromMongoBenchmark.mongoValueToCaseClass      thrpt   10  28,450 ± 0,218  ops/s
+Benchmark                                  Mode  Cnt    Score    Error  Units
+FromMongoBenchmark.mongoValueToCaseClass  thrpt   10   27,106 ±  0,190  ops/s
+FromMongoBenchmark.mongoValueToList       thrpt   10  372,471 ±  9,231  ops/s
+FromMongoBenchmark.mongoValueToMap        thrpt   10   74,411 ±  0,238  ops/s
+FromMongoBenchmark.mongoValueToVector     thrpt   10  592,723 ± 49,853  ops/s
  */
 
   @Benchmark
   def mongoValueToCaseClass(): Unit = {
     val product = fromMongo[Product](JsonBenchmark.productMongoValue)
     assert(product.version == 2)
+  }
+
+  @Benchmark
+  def mongoValueToVector(): Unit = {
+    val vector = fromMongo[Vector[Int]](JsonBenchmark.lotsOfIntsMongoValue)
+    assert(JsonBenchmark.lotsOfIntsVector.size == vector.size)
+  }
+
+  @Benchmark
+  def mongoValueToList(): Unit = {
+    val list = fromMongo[List[Int]](JsonBenchmark.lotsOfIntsMongoValue)
+    assert(JsonBenchmark.lotsOfIntsVector.size == list.size)
+  }
+
+  @Benchmark
+  def mongoValueToMap(): Unit = {
+    val map = fromMongo[Map[String, String]](JsonBenchmark.bigMapMongoValue)
+    assert(JsonBenchmark.bigMap.size == map.size)
   }
 
 }

--- a/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
+++ b/benchmarks/src/main/scala/json/FromMongoBenchmark.scala
@@ -15,11 +15,11 @@ class FromMongoBenchmark {
 jmh:run
 
 *** scala 2.13 ***
-Benchmark                                  Mode  Cnt    Score    Error  Units
-FromMongoBenchmark.mongoValueToCaseClass  thrpt   10   27,106 ±  0,190  ops/s
-FromMongoBenchmark.mongoValueToList       thrpt   10  372,471 ±  9,231  ops/s
-FromMongoBenchmark.mongoValueToMap        thrpt   10   74,411 ±  0,238  ops/s
-FromMongoBenchmark.mongoValueToVector     thrpt   10  592,723 ± 49,853  ops/s
+Benchmark                                  Mode  Cnt     Score    Error  Units
+FromMongoBenchmark.mongoValueToCaseClass  thrpt   10    25,306 ±  0,832  ops/s
+FromMongoBenchmark.mongoValueToList       thrpt   10   521,449 ± 17,672  ops/s
+FromMongoBenchmark.mongoValueToMap        thrpt   10    51,554 ±  0,648  ops/s
+FromMongoBenchmark.mongoValueToVector     thrpt   10  1334,286 ± 21,065  ops/s
  */
 
   @Benchmark

--- a/benchmarks/src/main/scala/json/JsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/JsonBenchmark.scala
@@ -62,6 +62,9 @@ object JsonBenchmark {
   val lotsOfIntsSeq = Range(1, 100000).toSeq
   val lotsOfIntsVector = Range(1, 100000).toVector
   val lotsOfIntsAsJson = Range(1, 100000).mkString("[", ",", "]")
+  val lotsOfIntsMongoValue = toMongo(lotsOfIntsVector)
+  val bigMap: Map[String, String] = lotsOfIntsList.map(i => s"key$i" -> s"value$i").toMap
+  val bigMapMongoValue = toMongo(bigMap)
 
   val prices = for (i <- 1 to 200) yield
     s"""

--- a/benchmarks/src/main/scala/json/ToMongoValueBenchmark.scala
+++ b/benchmarks/src/main/scala/json/ToMongoValueBenchmark.scala
@@ -1,6 +1,7 @@
 package json
 
 import io.sphere.mongo.format._
+import io.sphere.mongo.format.DefaultMongoFormats._
 import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Fork, Measurement, Mode, Scope, State, Warmup}
 
 @State(Scope.Benchmark)
@@ -13,19 +14,34 @@ class ToMongoValueBenchmark {
   /* on local mac
 jmh:run
 
-*** scala 2.12 ***
-Benchmark                                     Mode  Cnt   Score   Error  Units
-ToMongoValueBenchmark.caseClassToMongoValue   thrpt   10  79,065 ± 1,075  ops/s
-
-*** scala 2.13 ***
-Benchmark                                     Mode  Cnt   Score   Error  Units
-ToMongoValueBenchmark.caseClassToMongoValue   thrpt   10  80,242 ± 1,033  ops/s
-*/
-
+[info] Benchmark                                     Mode  Cnt    Score    Error  Units
+[info] ToMongoValueBenchmark.caseClassToMongoValue  thrpt   10   76,492 ±  0,968  ops/s
+[info] ToMongoValueBenchmark.listToMongoValue       thrpt   10  484,802 ± 16,722  ops/s
+[info] ToMongoValueBenchmark.mapToMongoValueTo      thrpt   10   30,316 ±  3,938  ops/s
+[info] ToMongoValueBenchmark.vectorToMongoValue     thrpt   10  671,930 ± 17,021  ops/s
+ */
 
   @Benchmark
   def caseClassToMongoValue(): Unit = {
     val mongoValue = toMongo[Product](JsonBenchmark.product)
+    assert(mongoValue != null)
+  }
+
+  @Benchmark
+  def vectorToMongoValue(): Unit = {
+    val mongoValue = toMongo[Vector[Int]](JsonBenchmark.lotsOfIntsVector)
+    assert(mongoValue != null)
+  }
+
+  @Benchmark
+  def listToMongoValue(): Unit = {
+    val mongoValue = toMongo[List[Int]](JsonBenchmark.lotsOfIntsList)
+    assert(mongoValue != null)
+  }
+
+  @Benchmark
+  def mapToMongoValueTo(): Unit = {
+    val mongoValue = toMongo[Map[String, String]](JsonBenchmark.bigMap)
     assert(mongoValue != null)
   }
 

--- a/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
+++ b/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
@@ -2,9 +2,13 @@ package io.sphere.mongo.format
 
 import java.util.{Currency, Locale, UUID}
 import java.util.regex.Pattern
+
 import io.sphere.util.{BaseMoney, HighPrecisionMoney, LangTag, Money}
 import org.bson.{BSONObject, BasicBSONObject}
 import org.bson.types.{BasicBSONList, ObjectId}
+
+import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable.ListBuffer
 
 object DefaultMongoFormats extends DefaultMongoFormats {
   val someNone = Some(None)
@@ -78,7 +82,13 @@ trait DefaultMongoFormats {
     override def fromMongoValue(any: Any): Vector[A] = {
       any match {
         case l: BasicBSONList =>
-          l.iterator().asScala.map(f.fromMongoValue).toVector
+          val builder = new VectorBuilder[A]
+          val iter = l.iterator()
+          while (iter.hasNext) {
+            val element = iter.next()
+            builder += f.fromMongoValue(element)
+          }
+          builder.result()
         case _ => throw new Exception(s"cannot read value from ${any.getClass.getName}")
       }
     }
@@ -94,7 +104,13 @@ trait DefaultMongoFormats {
     override def fromMongoValue(any: Any): List[A] = {
       any match {
         case l: BasicBSONList =>
-          l.iterator().asScala.map(f.fromMongoValue).toList
+          val builder = new ListBuffer[A]
+          val iter = l.iterator()
+          while (iter.hasNext) {
+            val element = iter.next()
+            builder += f.fromMongoValue(element)
+          }
+          builder.result()
         case _ => throw new Exception(s"cannot read value from ${any.getClass.getName}")
       }
     }


### PR DESCRIPTION
This PR optimises `FromMongo` for `List` and `Vector`.

To do I introduced new benchmarks with tests data.

I removed the Scala 2.12 results as they are expensive to keep in sync.

TLDR: 2x improvement on `Vector` and 1.3x on `List`
