### PR TITLE
scala 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.12.11
-  - 2.13.2
+  - 2.13.3
 
 jdk:
   - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val publishSettings = Seq(
 
 lazy val standardSettings = Defaults.coreDefaultSettings ++ publishSettings ++ Seq(
   organization := "io.sphere",
-  scalaVersion := "2.13.2",
+  scalaVersion := "2.13.3",
   crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   logBuffered := false,

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -205,7 +205,7 @@ package object generic extends Logging {
     * This can be used as an alternative to an enum.
     */
   def toJsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : ToJSON](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
-    val inSelectors: List[TypeSelectorToJSON[_]] = typeSelectorToJSON[A] :: selectors
+    val inSelectors: List[TypeSelectorToJSON[_]] = typeSelectorToJSON[A]() :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
       case container: TypeSelectorToJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
@@ -214,7 +214,7 @@ package object generic extends Logging {
     allSelectors.foreach { s =>
       writeMapBuilder += (s.clazz -> s)
     }
-    val writeMap = writeMapBuilder.result
+    val writeMap = writeMapBuilder.result()
 
     new ToJSON[T] with TypeSelectorToJSONContainer {
       override def typeSelectors = allSelectors
@@ -239,7 +239,7 @@ package object generic extends Logging {
     */
   def fromJsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
     val readMapBuilder = Map.newBuilder[String, TypeSelectorFromJSON[_]]
-    val inSelectors: List[TypeSelectorFromJSON[_]] = typeSelectorFromJSON[A] :: selectors
+    val inSelectors: List[TypeSelectorFromJSON[_]] = typeSelectorFromJSON[A]() :: selectors
     val allSelectors = inSelectors.flatMap(s => s.jsonr match {
       case container: TypeSelectorFromJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
@@ -247,7 +247,7 @@ package object generic extends Logging {
     allSelectors.foreach { s =>
       readMapBuilder += (s.typeValue -> s)
     }
-    val readMap = readMapBuilder.result
+    val readMap = readMapBuilder.result()
 
     new FromJSON[T] with TypeSelectorFromJSONContainer {
       override def typeSelectors = allSelectors
@@ -271,7 +271,7 @@ package object generic extends Logging {
     * This can be used as an alternative to an enum.
     */
   def jsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON : ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
-    val inSelectors = typeSelector[A] :: selectors
+    val inSelectors = typeSelector[A]() :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
       case container: TypeSelectorContainer => container.typeSelectors :+ s
       case _ => s :: Nil
@@ -292,26 +292,26 @@ package object generic extends Logging {
   <#list 2..20 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def toJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}] :: selectors)
+  def toJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}]() :: selectors)
   </#list>
 
   <#list 2..20 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def fromJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}] :: selectors)
+  def fromJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}]() :: selectors)
   </#list>
 
   <#list 2..20 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def jsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonSingletonEnumSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
+  def jsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonSingletonEnumSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
   </#list>
 
   /** Creates a `ToJSON[T]` instance for some supertype `T`. The instance acts as a type-switch
     * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
     * on a field that acts as a type hint. */
   def toJsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: ToJSON, A2 <: T: ClassTag: ToJSON](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
-    val inSelectors = typeSelectorToJSON[A1] :: typeSelectorToJSON[A2] :: selectors
+    val inSelectors = typeSelectorToJSON[A1]() :: typeSelectorToJSON[A2]() :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
       case container: TypeSelectorToJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
@@ -323,7 +323,7 @@ package object generic extends Logging {
       writeMapBuilder += (s.clazz -> s)
     }
 
-    val writeMap = writeMapBuilder.result
+    val writeMap = writeMapBuilder.result()
 
     new ToJSON[T] with TypeSelectorToJSONContainer {
       override def typeSelectors: List[TypeSelectorToJSON[_]] = allSelectors
@@ -345,7 +345,7 @@ package object generic extends Logging {
     * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
     * on a field that acts as a type hint. */
   def fromJsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON, A2 <: T: ClassTag: FromJSON](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
-    val inSelectors = typeSelectorFromJSON[A1] :: typeSelectorFromJSON[A2] :: selectors
+    val inSelectors = typeSelectorFromJSON[A1]() :: typeSelectorFromJSON[A2]() :: selectors
     val allSelectors = inSelectors.flatMap(s => s.jsonr match {
       case container: TypeSelectorFromJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
@@ -357,7 +357,7 @@ package object generic extends Logging {
       readMapBuilder += (s.typeValue -> s)
     }
 
-    val readMap = readMapBuilder.result
+    val readMap = readMapBuilder.result()
     val clazz = classTag[T].runtimeClass
 
     val fieldWithJSONTypeHint = clazz.getAnnotation(classOf[JSONTypeHintField])
@@ -384,7 +384,7 @@ package object generic extends Logging {
     * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
     * on a field that acts as a type hint. */
   def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON, A2 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
-    val inSelectors = typeSelector[A1] :: typeSelector[A2] :: selectors
+    val inSelectors = typeSelector[A1]() :: typeSelector[A2]() :: selectors
     val allSelectors = inSelectors.flatMap(s => s.serializer match {
       case container: TypeSelectorContainer => container.typeSelectors :+ s
       case _ => s :: Nil
@@ -409,19 +409,19 @@ package object generic extends Logging {
   <#list 3..84 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def toJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonTypeSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}] :: selectors)
+  def toJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonTypeSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}]() :: selectors)
   </#list>
 
   <#list 3..84 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def fromJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonTypeSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}] :: selectors)
+  def fromJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonTypeSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}]() :: selectors)
   </#list>
 
   <#list 3..84 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
+  def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
   </#list>
 
   trait TypeSelectorBase {

--- a/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/package.scala
+++ b/mongo/mongo-derivation-magnolia/src/main/scala/io/sphere/mongo/generic/package.scala
@@ -86,8 +86,8 @@ package object generic extends Logging {
       readMapBuilder += (s.typeValue -> s)
       writeMapBuilder += (s.subType.typeName -> s)
     }
-    private val readMap = readMapBuilder.result
-    private val writeMap = writeMapBuilder.result
+    private val readMap = readMapBuilder.result()
+    private val writeMap = writeMapBuilder.result()
 
     private val typeField = sealedTrait.annotations.collectFirst {
       case a: MongoTypeHintField => a.value

--- a/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
+++ b/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
@@ -115,15 +115,15 @@ package object generic extends Logging {
     * for the subtypes `A1` and `A2`, delegating to their respective MongoFormat instances based
     * on a field that acts as a type hint. */
   def mongoTypeSwitch[T: ClassTag, A1 <: T: ClassTag: MongoFormat, A2 <: T: ClassTag: MongoFormat](selectors: List[TypeSelector[_]]): MongoFormat[T] = {
-    val allSelectors = typeSelector[A1] :: typeSelector[A2] :: selectors
+    val allSelectors = typeSelector[A1]() :: typeSelector[A2]() :: selectors
     val readMapBuilder = Map.newBuilder[String, TypeSelector[_]]
     val writeMapBuilder = Map.newBuilder[Class[_], TypeSelector[_]]
     allSelectors.foreach { s =>
       readMapBuilder += (s.typeValue -> s)
       writeMapBuilder += (s.clazz -> s)
     }
-    val readMap = readMapBuilder.result
-    val writeMap = writeMapBuilder.result
+    val readMap = readMapBuilder.result()
+    val writeMap = writeMapBuilder.result()
     val clazz = classTag[T].runtimeClass
 
     val fieldWithMongoTypeHintField = clazz.getAnnotation(classOf[MongoTypeHintField])
@@ -163,7 +163,7 @@ package object generic extends Logging {
   <#list 3..80 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : MongoFormat : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def mongoTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): MongoFormat[T] = mongoTypeSwitch[T, ${typeParams}](typeSelector[A${i}] :: selectors)
+  def mongoTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): MongoFormat[T] = mongoTypeSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
   </#list>
 
   final class TypeSelector[A: MongoFormat] private[mongo](val typeField: String, val typeValue: String, val clazz: Class[_]) {

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -81,9 +81,9 @@ class MoneySpec extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyCh
     }
 
     it("should support partitioning an amount without losing or gaining money.") {
-      (0.05 EUR) partition (3,7) must equal (Seq(0.02 EUR, 0.03 EUR))
-      (10 EUR) partition (1,2) must equal (Seq(3.34 EUR, 6.66 EUR))
-      (10 EUR) partition (3,1,3) must equal (Seq(4.29 EUR, 1.43 EUR, 4.28 EUR))
+      (0.05 EUR).partition(3,7) must equal (Seq(0.02 EUR, 0.03 EUR))
+      (10 EUR).partition(1,2) must equal (Seq(3.34 EUR, 6.66 EUR))
+      (10 EUR).partition(3,1,3) must equal (Seq(4.29 EUR, 1.43 EUR, 4.28 EUR))
     }
 
     it("should allow comparing money with the same currency.") {


### PR DESCRIPTION
I had to remove a couple of warnings due to

```
 Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method typeSelector,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
```