### PR TITLE
[Scala 3 backport] JSONSpec add type ascriptions to implicits + 1 tes…

### DIFF
--- a/json/json-derivation/src/test/scala/io/sphere/json/JSONSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/JSONSpec.scala
@@ -13,6 +13,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 
 object JSONSpec {
+  case class Test(a: String)
+
   case class Project(nr: Int, name: String, version: Int = 1, milestones: List[Milestone] = Nil)
   case class Milestone(name: String, date: Option[DateTime] = None)
 
@@ -25,7 +27,7 @@ object JSONSpec {
   case class GenericA[A](a: A) extends GenericBase[A]
   case class GenericB[A](a: A) extends GenericBase[A]
 
-  object Singleton
+  case object Singleton
 
   sealed abstract class SingletonEnum
   case object SingletonA extends SingletonEnum
@@ -46,6 +48,25 @@ object JSONSpec {
 class JSONSpec extends AnyFunSpec with Matchers {
   import JSONSpec._
 
+  describe("JSON.apply") {
+    it("must find custom JSON instance in scope") {
+      implicit val testJson: JSON[Test] = new JSON[Test] {
+        override def read(jval: JValue): JValidation[Test] = ???
+        override def write(value: Test): JValue = ???
+      }
+
+      JSON[Test] must be(testJson)
+    }
+
+    it("must create instance from FromJSON and ToJSON") {
+      def check[A](json: JSON[A], a: A) = json.read(json.write(a)).expectValid must be(a)
+
+      check(JSON[Int], 123)
+      check(JSON[List[Double]], List(3.4))
+      check(JSON[Map[String, Int]], Map("asd" -> 234))
+    }
+  }
+
   describe("JSON") {
     it("must read/write a custom class using custom typeclass instances") {
       import JSONSpec.{Milestone, Project}
@@ -57,7 +78,7 @@ class JSONSpec extends AnyFunSpec with Matchers {
         )
         def read(j: JValue): ValidatedNel[JSONError, Milestone] = j match {
           case o: JObject =>
-            (field[String]("name")(o), field[Option[DateTime]]("date")(o)).mapN(Milestone)
+            (field[String]("name")(o), field[Option[DateTime]]("date")(o)).mapN(Milestone.apply)
           case _ => fail("JSON object expected.")
         }
       }
@@ -74,7 +95,7 @@ class JSONSpec extends AnyFunSpec with Matchers {
               field[Int]("nr")(o),
               field[String]("name")(o),
               field[Int]("version", Some(1))(o),
-              field[List[Milestone]]("milestones", Some(Nil))(o)).mapN(Project)
+              field[List[Milestone]]("milestones", Some(Nil))(o)).mapN(Project.apply)
           case _ => fail("JSON object expected.")
         }
       }
@@ -92,7 +113,7 @@ class JSONSpec extends AnyFunSpec with Matchers {
       }
       """
       val errs = fromJSON[Project](wrongTypeJSON).expectErrors
-      errs.toList must equal(
+      errs must equal(
         List(
           JSONFieldError(List("nr"), "JSON Number in the range of an Int expected."),
           JSONFieldError(List("name"), "JSON String expected."),
@@ -111,8 +132,8 @@ class JSONSpec extends AnyFunSpec with Matchers {
 
     it("must provide derived JSON instances for product types (case classes)") {
       import JSONSpec.{Milestone, Project}
-      implicit val milestoneJSON = deriveJSON[Milestone]
-      implicit val projectJSON = deriveJSON[Project]
+      implicit val milestoneJSON: JSON[Milestone] = deriveJSON
+      implicit val projectJSON: JSON[Project] = deriveJSON
       val proj =
         Project(42, "Linux", 7, Milestone("1.0") :: Milestone("2.0") :: Milestone("3.0") :: Nil)
       fromJSON[Project](toJSON(proj)) must equal(Valid(proj))
@@ -140,47 +161,47 @@ class JSONSpec extends AnyFunSpec with Matchers {
     }
 
     it("must provide derived JSON instances for sum types") {
-      implicit val animalJSON = deriveJSON[Animal]
-      List(Bird("Peewee"), Dog("Hasso"), Cat("Felidae")).foreach { a: Animal =>
+      implicit val animalJSON: JSON[Animal] = deriveJSON
+      List(Bird("Peewee"), Dog("Hasso"), Cat("Felidae")).foreach { (a: Animal) =>
         fromJSON[Animal](toJSON(a)) must equal(Valid(a))
       }
     }
 
     it("must provide derived instances for product types with concrete type parameters") {
-      implicit val aJSON = deriveJSON[GenericA[String]]
+      implicit val aJSON: JSON[GenericA[String]] = deriveJSON[GenericA[String]]
       val a = GenericA("hello")
       fromJSON[GenericA[String]](toJSON(a)) must equal(Valid(a))
     }
 
     it("must provide derived instances for product types with generic type parameters") {
-      implicit def aJSON[A: FromJSON: ToJSON] = deriveJSON[GenericA[A]]
+      implicit def aJSON[A: FromJSON: ToJSON]: JSON[GenericA[A]] = deriveJSON[GenericA[A]]
       val a = GenericA("hello")
       fromJSON[GenericA[String]](toJSON(a)) must equal(Valid(a))
     }
 
     it("must provide derived instances for singleton objects") {
-      implicit val singletonJSON = deriveJSON[Singleton.type]
+      implicit val singletonJSON: JSON[Singleton.type] = deriveJSON[Singleton.type]
       val json = s"""[${toJSON(Singleton)}]"""
       withClue(json) {
         fromJSON[Seq[Singleton.type]](json) must equal(Valid(Seq(Singleton)))
       }
 
-      implicit val singleEnumJSON = deriveJSON[SingletonEnum]
-      List(SingletonA, SingletonB, SingletonC).foreach { s: SingletonEnum =>
+      implicit val singleEnumJSON: JSON[SingletonEnum] = deriveJSON[SingletonEnum]
+      List(SingletonA, SingletonB, SingletonC).foreach { (s: SingletonEnum) =>
         fromJSON[SingletonEnum](toJSON(s)) must equal(Valid(s))
       }
     }
 
     it("must provide derived instances for sum types with a mix of case class / object") {
-      implicit val mixedJSON = deriveJSON[Mixed]
+      implicit val mixedJSON: JSON[Mixed] = deriveJSON
 
-      List(SingletonMixed, RecordMixed(1)).foreach { m: Mixed =>
+      List(SingletonMixed, RecordMixed(1)).foreach { (m: Mixed) =>
         fromJSON[Mixed](toJSON(m)) must equal(Valid(m))
       }
     }
 
     it("must provide derived instances for scala.Enumeration") {
-      implicit val scalaEnumJSON: JSON[JSONSpec.ScalaEnum.Value] = jsonEnum(ScalaEnum)
+      implicit val scalaEnumJSON: JSON[ScalaEnum.Value] = jsonEnum(ScalaEnum)
       ScalaEnum.values.foreach { v =>
         val json = s"""[${toJSON(v)}]"""
         withClue(json) {
@@ -216,14 +237,15 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val birdToJSON: ToJSON[Bird] = deriveToJSON
       implicit val dogToJSON: ToJSON[Dog] = deriveToJSON
       implicit val catToJSON: ToJSON[Cat] = deriveToJSON
-      implicit val animalToJSON = toJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
+      implicit val animalToJSON: ToJSON[Animal] = toJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
       // FromJSON
       implicit val birdFromJSON: FromJSON[Bird] = deriveFromJSON
       implicit val dogFromJSON: FromJSON[Dog] = deriveFromJSON
       implicit val catFromJSON: FromJSON[Cat] = deriveFromJSON
-      implicit val animalFromJSON = fromJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
+      implicit val animalFromJSON: FromJSON[Animal] =
+        fromJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
 
-      List(Bird("Peewee"), Dog("Hasso"), Cat("Felidae")).foreach { (a: Animal) =>
+      List[Animal](Bird("Peewee"), Dog("Hasso"), Cat("Felidae")).foreach { a =>
         fromJSON[Animal](toJSON(a)) must equal(Valid(a))
       }
     }
@@ -236,25 +258,25 @@ class JSONSpec extends AnyFunSpec with Matchers {
     }
 
     it("must provide derived instances for singleton objects") {
-      implicit val toSingletonJSON = toJsonSingleton(Singleton)
-      implicit val fromSingletonJSON = fromJsonSingleton(Singleton)
+      implicit val toSingletonJSON: ToJSON[Singleton.type] = toJsonSingleton(Singleton)
+      implicit val fromSingletonJSON: FromJSON[Singleton.type] = fromJsonSingleton(Singleton)
       val json = s"""[${toJSON(Singleton)}]"""
       withClue(json) {
         fromJSON[Seq[Singleton.type]](json) must equal(Valid(Seq(Singleton)))
       }
 
       // ToJSON
-      implicit val toSingleAJSON = toJsonSingleton(SingletonA)
-      implicit val toSingleBJSON = toJsonSingleton(SingletonB)
-      implicit val toSingleCJSON = toJsonSingleton(SingletonC)
-      implicit val toSingleEnumJSON =
+      implicit val toSingleAJSON: ToJSON[SingletonA.type] = toJsonSingleton(SingletonA)
+      implicit val toSingleBJSON: ToJSON[SingletonB.type] = toJsonSingleton(SingletonB)
+      implicit val toSingleCJSON: ToJSON[SingletonC.type] = toJsonSingleton(SingletonC)
+      implicit val toSingleEnumJSON: ToJSON[SingletonEnum] =
         toJsonSingletonEnumSwitch[SingletonEnum, SingletonA.type, SingletonB.type, SingletonC.type](
           Nil)
       // FromJSON
-      implicit val fromSingleAJSON = fromJsonSingleton(SingletonA)
-      implicit val fromSingleBJSON = fromJsonSingleton(SingletonB)
-      implicit val fromSingleCJSON = fromJsonSingleton(SingletonC)
-      implicit val fromSingleEnumJSON = fromJsonSingletonEnumSwitch[
+      implicit val fromSingleAJSON: FromJSON[SingletonA.type] = fromJsonSingleton(SingletonA)
+      implicit val fromSingleBJSON: FromJSON[SingletonB.type] = fromJsonSingleton(SingletonB)
+      implicit val fromSingleCJSON: FromJSON[SingletonC.type] = fromJsonSingleton(SingletonC)
+      implicit val fromSingleEnumJSON: FromJSON[SingletonEnum] = fromJsonSingletonEnumSwitch[
         SingletonEnum,
         SingletonA.type,
         SingletonB.type,
@@ -269,19 +291,21 @@ class JSONSpec extends AnyFunSpec with Matchers {
       // ToJSON
       implicit val toSingleJSON: ToJSON[JSONSpec.SingletonMixed.type] = deriveToJSON
       implicit val toRecordJSON: ToJSON[RecordMixed] = deriveToJSON
-      implicit val toMixedJSON = toJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
+      implicit val toMixedJSON: ToJSON[Mixed] =
+        toJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
       // FromJSON
       implicit val fromSingleJSON: FromJSON[JSONSpec.SingletonMixed.type] = deriveFromJSON
       implicit val fromRecordJSON: FromJSON[RecordMixed] = deriveFromJSON
-      implicit val fromMixedJSON = fromJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
+      implicit val fromMixedJSON: FromJSON[Mixed] =
+        fromJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
       List(SingletonMixed, RecordMixed(1)).foreach { m: Mixed =>
         fromJSON[Mixed](toJSON(m)) must equal(Valid(m))
       }
     }
 
     it("must provide derived instances for scala.Enumeration") {
-      implicit val toScalaEnumJSON = toJsonEnum(ScalaEnum)
-      implicit val fromScalaEnumJSON = fromJsonEnum(ScalaEnum)
+      implicit val toScalaEnumJSON: ToJSON[ScalaEnum.Value] = toJsonEnum(ScalaEnum)
+      implicit val fromScalaEnumJSON: FromJSON[ScalaEnum.Value] = fromJsonEnum(ScalaEnum)
       ScalaEnum.values.foreach { v =>
         val json = s"""[${toJSON(v)}]"""
         withClue(json) {
@@ -296,11 +320,11 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val to2: ToJSON[TestSubjectConcrete2] = deriveToJSON
       implicit val to3: ToJSON[TestSubjectConcrete3] = deriveToJSON
       implicit val to4: ToJSON[TestSubjectConcrete4] = deriveToJSON
-      implicit val toA =
+      implicit val toA: ToJSON[TestSubjectCategoryA] =
         toJsonTypeSwitch[TestSubjectCategoryA, TestSubjectConcrete1, TestSubjectConcrete2](Nil)
-      implicit val toB =
+      implicit val toB: ToJSON[TestSubjectCategoryB] =
         toJsonTypeSwitch[TestSubjectCategoryB, TestSubjectConcrete3, TestSubjectConcrete4](Nil)
-      implicit val toBase =
+      implicit val toBase: ToJSON[TestSubjectBase] =
         toJsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
 
       // FromJSON
@@ -308,11 +332,11 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val from2: FromJSON[TestSubjectConcrete2] = deriveFromJSON
       implicit val from3: FromJSON[TestSubjectConcrete3] = deriveFromJSON
       implicit val from4: FromJSON[TestSubjectConcrete4] = deriveFromJSON
-      implicit val fromA =
+      implicit val fromA: FromJSON[TestSubjectCategoryA] =
         fromJsonTypeSwitch[TestSubjectCategoryA, TestSubjectConcrete1, TestSubjectConcrete2](Nil)
-      implicit val fromB =
+      implicit val fromB: FromJSON[TestSubjectCategoryB] =
         fromJsonTypeSwitch[TestSubjectCategoryB, TestSubjectConcrete3, TestSubjectConcrete4](Nil)
-      implicit val fromBase =
+      implicit val fromBase: FromJSON[TestSubjectBase] =
         fromJsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
 
       val testSubjects = List[TestSubjectBase](
@@ -369,8 +393,8 @@ object TestSubjectCategoryB {
 
 object TestSubjectBase {
   val json: JSON[TestSubjectBase] = {
-    implicit val jsonA = TestSubjectCategoryA.json
-    implicit val jsonB = TestSubjectCategoryB.json
+    implicit val jsonA: JSON[TestSubjectCategoryA] = TestSubjectCategoryA.json
+    implicit val jsonB: JSON[TestSubjectCategoryB] = TestSubjectCategoryB.json
 
     jsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
   }


### PR DESCRIPTION
…t case for JSON.apply

- Scala 3 doesn't compile with inferred implicit vals, so this was a necessary addition there. 