### PR TITLE
Add 2 test cases:

### DIFF
--- a/json/json-derivation/src/test/scala/io/sphere/json/OptionReaderSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/OptionReaderSpec.scala
@@ -1,6 +1,9 @@
 package io.sphere.json
 
 import io.sphere.json.generic._
+import io.sphere.util.BaseMoney
+import io.sphere.util.Money.ImplicitsDecimal._
+import io.sphere.util.test._
 import org.json4s.{JArray, JLong, JNothing, JObject, JString}
 import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
@@ -29,6 +32,8 @@ object OptionReaderSpec {
   object ListClass {
     implicit val json: JSON[ListClass] = deriveJSON
   }
+
+  case class MoneyOptClass(moneyOpt: Option[BaseMoney])
 }
 
 class OptionReaderSpec extends AnyWordSpec with Matchers with OptionValues {
@@ -144,6 +149,18 @@ class OptionReaderSpec extends AnyWordSpec with Matchers with OptionValues {
 
       parseJSON(toJSON(result)) mustEqual parseJSON(json)
     }
+  }
+
+  "use predefined Option & BaseMoney instances instead of deriving them" in {
+    // This is relevant because some instances can get derived when the instances are not in the right scope
+    // I had it happen for Option[BaseMoney] while I was moving things around
+    // This test ensures we use the predefined instances
+    val action = MoneyOptClass(Some(10.EUR))
+
+    val format: JSON[MoneyOptClass] = deriveJSON
+    val action2 = format.read(format.write(action)).expectValid
+
+    action must be(action2)
   }
 
 }

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/NestedSubTypeNameSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/NestedSubTypeNameSpec.scala
@@ -1,0 +1,37 @@
+package io.sphere.json.generic
+
+import io.sphere.json.JSON
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class NestedSubTypeNameSpec extends AnyWordSpec with Matchers {
+  import NestedSubTypeNameSpec._
+
+  "return all subtype names in nested trait hierarchies" in {
+    val format: JSON[SuperType2] =
+      jsonTypeSwitch[SuperType2, SubType1, SubType2](Nil)
+
+    val names =
+      // There are 2 strange things about this list:
+      // 1: Trait names are also listen, not only class names, even though we don't use those
+      // 2: Class names seem to be duplicated
+      // I don't think this behaviour is necessarily intentional, but it works like this at the moment.
+      List("SubClass1A", "SubClass1A", "SubType1", "SubClass2A", "SubClass2A", "SubType2")
+    format.asInstanceOf[TypeSelectorContainer].typeSelectors.map(_.typeValue) must be(names)
+    format.subTypeNames must be(names)
+  }
+}
+
+object NestedSubTypeNameSpec {
+  sealed trait SuperType2
+  sealed trait SubType1 extends SuperType2
+  object SubType1 {
+    case class SubClass1A(x: Int) extends SubType1
+    implicit val json: JSON[SubType1] = deriveJSON
+  }
+  sealed trait SubType2 extends SuperType2
+  object SubType2 {
+    case class SubClass2A(x: Int) extends SubType2
+    implicit val json: JSON[SubType2] = deriveJSON
+  }
+}

--- a/util-test/src/main/scala/io/sphere/util/test.scala
+++ b/util-test/src/main/scala/io/sphere/util/test.scala
@@ -1,8 +1,8 @@
 package io.sphere.util
 
-import org.scalatest.Assertions._
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.ValidatedNel
+import org.scalatest.Assertions._
 
 package object test {
   implicit class ValidatedNelTestOps[Err, A](val validatedNel: ValidatedNel[Err, A])


### PR DESCRIPTION
1. Ensure nested type class instances of traits are used instead of getting derived
2. Add test for subTypeNames for nested sealed traits